### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+## Contributing to ORCA
+
+- [Fork this repo](https://help.github.com/articles/fork-a-repo/) to your own user
+- Set your fork as origin, and this repo as upstream. From inside the `orca` folder:
+
+  ```
+  git remote rm origin
+  git remote add origin git@github.com:<your-username>/orca.git
+  git remote add upstream git@github.com:acquia/orca.git
+  ```
+
+- Make your proposed changes on a [branch](https://guides.github.com/activities/hello-world/#branch) and then push them to your fork
+
+  ```
+  git push origin <your-branch>
+  ```
+
+- [Make a pull request](https://help.github.com/articles/about-pull-requests/)!
+- Switch back to master and pull in the latest changes
+
+  ```
+  git checkout master
+  git pull upstream master
+  ```
+
+- Our [issue queue](https://github.com/acquia/orca/issues) is public and you already have the required permissions to participate.


### PR DESCRIPTION
Per https://confluence.acquia.com/display/ENG/Open+Sourcing+Acquia+Software and confirmation from Jake Farrel that this will be required even though we don't expect or want to encourage others to contribute. I left it intentionally vague, just literally describing the process.