### PR TITLE
Install Drupal using SQLite by default, not MySQL

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -149,7 +149,7 @@ abstract class CommandBase extends Tasks {
           'minimal',
           "install_configure_form.update_status_module='[FALSE,FALSE]'",
           "install_configure_form.enable_update_status_module=NULL",
-          "--db-url=sqlite://localhost/drupal.sqlite",
+          "--db-url=sqlite://sites/default/files/.ht.sqlite",
           "--site-name=ORCA",
           "--account-name=admin",
           "--account-pass=admin",


### PR DESCRIPTION
Drupal core fully supports SQLite, and given that ORCA is portable across environments, it should install in a SQLite database by default. The benefit there is that SQLite, if available, does not require any additional servers to be running or credentials to be set up, so we won't have to figure out a way to pass MySQL or Postgres credentials to ORCA -- at least, not for now.

This will make it a lot easier to prepare phpunit.xml for testing.