### PR TITLE
Run Behat tests from the fixture root

### DIFF
--- a/src/Tests/Tester.php
+++ b/src/Tests/Tester.php
@@ -222,7 +222,6 @@ class Tester {
     foreach ($this->getBehatConfigFiles() as $config_file) {
       $this->runVendorBinProcess([
         'behat',
-        '--dry-run',
         "--config={$config_file->getPathname()}",
       ], $this->facade->rootPath());
     }

--- a/src/Tests/Tester.php
+++ b/src/Tests/Tester.php
@@ -222,8 +222,9 @@ class Tester {
     foreach ($this->getBehatConfigFiles() as $config_file) {
       $this->runVendorBinProcess([
         'behat',
+        '--dry-run',
         "--config={$config_file->getPathname()}",
-      ]);
+      ], $this->facade->rootPath());
     }
   }
 


### PR DESCRIPTION
Right now, Behat is run from the ORCA directory. It needs to be run from the fixture root so that any relative paths in the behat.yml files are resolved properly.