### PR TITLE
Pass --colors option to Behat

### DIFF
--- a/src/Tests/Tester.php
+++ b/src/Tests/Tester.php
@@ -222,6 +222,7 @@ class Tester {
     foreach ($this->getBehatConfigFiles() as $config_file) {
       $this->runVendorBinProcess([
         'behat',
+        "--colors",
         "--config={$config_file->getPathname()}",
       ], $this->facade->rootPath());
     }

--- a/src/Tests/Tester.php
+++ b/src/Tests/Tester.php
@@ -222,7 +222,7 @@ class Tester {
     foreach ($this->getBehatConfigFiles() as $config_file) {
       $this->runVendorBinProcess([
         'behat',
-        "--colors",
+        '--colors',
         "--config={$config_file->getPathname()}",
       ], $this->facade->rootPath());
     }


### PR DESCRIPTION
Right now, Behat's color text output (which are hugely helpful) is suppressed. If we pass the --colors option, they will be restored. This is a super useful debugging feature, so let's pass that option when running Behat.