### PR TITLE
Use 127.0.0.1:8080 for localhost constant

### DIFF
--- a/src/Tests/Tester.php
+++ b/src/Tests/Tester.php
@@ -20,7 +20,7 @@ class Tester {
   use IoTrait;
   use ProcessRunnerTrait;
 
-  private const WEB_ADDRESS = 'localhost:8000';
+  private const WEB_ADDRESS = '127.0.0.1:8080';
 
   /**
    * The web server process.


### PR DESCRIPTION
Why?

1) Port 8080 is used by Lightning and all of its components for testing. Seeing as how 8000 was not chosen for any particular reason, it's easier for ORCA to use 8080 than for Lightning to change over to 8000.
2) 'localhost' won't always work under certain circumstances. Mink, for example, doesn't seem to know what to do with it. 127.0.0.1 is a synonym that will always work, and it's also what Lightning universally uses. So, easier to change it here, now.