### PR TITLE
Override bootstrap container definition when installing Drupal

### DIFF
--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -286,7 +286,7 @@ class Creator {
    */
   private function installDrupal(): void {
     $this->io()->section('Installing Drupal');
-    $this->ensureDatabaseSettings();
+    $this->ensureDrupalSettings();
     $this->runProcess([
       'vendor/bin/drush',
       'site-install',
@@ -304,11 +304,11 @@ class Creator {
   }
 
   /**
-   * Ensure that Drupal is correctly configured to use the database.
+   * Ensure that Drupal is correctly configured.
    */
-  protected function ensureDatabaseSettings() {
+  protected function ensureDrupalSettings() {
     $filename = $this->facade->docrootPath('sites/default/settings/local.settings.php');
-    $id = '# ORCA DB settings.';
+    $id = '# ORCA settings.';
 
     // Return early if the settings are already present.
     if (strpos(file_get_contents($filename), $id)) {


### PR DESCRIPTION
This is a workaround for https://www.drupal.org/project/drupal/issues/3006038.

We need db-tools.php to work in order for Lightning to be able to test its update path. To support SQLite, which ORCA uses as the Drupal database backend, Lightning components must use db-tools.php to import the database dumps of previous versions. However, due to a bug, db-tools.php's import operation is broken. Overriding the bootstrap container definition such that the cache.container backend is memory-based works around it. This can only be done in settings.php.