### PR TITLE
Confine test runs to orca_public group/suite

### DIFF
--- a/src/Task/BehatTask.php
+++ b/src/Task/BehatTask.php
@@ -20,6 +20,7 @@ class BehatTask extends TaskBase {
           'behat',
           '--colors',
           "--config={$config_file->getPathname()}",
+          "--suite=orca_public",
         ], $this->fixture->rootPath());
       }
     }

--- a/src/Task/BehatTask.php
+++ b/src/Task/BehatTask.php
@@ -20,7 +20,7 @@ class BehatTask extends TaskBase {
           'behat',
           '--colors',
           "--config={$config_file->getPathname()}",
-          "--suite=orca_public",
+          "--tags=orca_public",
         ], $this->fixture->rootPath());
       }
     }

--- a/src/Task/PhpUnitTask.php
+++ b/src/Task/PhpUnitTask.php
@@ -138,6 +138,7 @@ class PhpUnitTask extends TaskBase {
         '--stop-on-failure',
         "--configuration={$this->fixture->docrootPath('core/phpunit.xml.dist')}",
         "--bootstrap={$this->fixture->docrootPath('core/tests/bootstrap.php')}",
+        "--group=orca_public",
         $this->fixture->testsDirectory(),
       ]);
     }


### PR DESCRIPTION
Products that integrate with ORCA need to have a way to expose specific tests to it. For this purpose, let's make it so that ORCA's tests:run command only runs PHPUnit tests that have the `orca_public` group, and executes Behat suites named `orca_public`.

Behat will need to use a test suite, rather than a tag, because the configuration for running those tests under an ORCA fixture may differ from other situations, and in Behat, the only way to ensure that a set-up like that works properly is to use a test suite.