### PR TITLE
Add support for weitzman/drupal-test-traits

### DIFF
--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -64,6 +64,7 @@ class Creator {
     $this->createBltProject();
     $this->removeUnneededProjects();
     $this->addAcquiaProductModules();
+    $this->requireTestingDependencies();
     $this->installDrupal();
     $this->installAcquiaProductModules();
     $this->createBackupBranch();
@@ -143,7 +144,6 @@ class Creator {
     $this->output->section('Adding Acquia product modules');
     $this->configureComposer();
     $this->requireDependencies();
-    $this->requireTestingDependencies();
     if ($this->sut) {
       $this->forceSutSymlinkInstall();
     }

--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -143,6 +143,7 @@ class Creator {
     $this->output->section('Adding Acquia product modules');
     $this->configureComposer();
     $this->requireDependencies();
+    $this->requireTestingDependencies();
     if ($this->sut) {
       $this->forceSutSymlinkInstall();
     }
@@ -228,6 +229,16 @@ class Creator {
   }
 
   /**
+   * Requires testing dependencies via Composer.
+   */
+  private function requireTestingDependencies(): void {
+    $this->processRunner->runExecutableProcess(array_merge(
+      ['composer', 'require', '--dev'],
+      $this->getTestingDependencies()
+    ), $this->fixture->rootPath());
+  }
+
+  /**
    * Forces Composer to install the SUT from the local path repository.
    */
   private function forceSutSymlinkInstall(): void {
@@ -259,11 +270,20 @@ class Creator {
       $dependencies[$this->sut] = $sut_package_string;
     }
 
+    return array_values($dependencies);
+  }
+
+  /**
+   * Gets the list of Composer testing dependency strings.
+   *
+   * @return string[]
+   */
+  private function getTestingDependencies(): array {
     // Add drupal-test-traits so that PHPUnit tests can be run against an
     // installed Drupal site.
-    $dependencies['weitzman/drupal-test-traits'] = 'weitzman/drupal-test-traits:dev-master';
-
-    return array_values($dependencies);
+    return [
+      'weitzman/drupal-test-traits:dev-master',
+    ];
   }
 
   /**

--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -236,6 +236,7 @@ class Creator {
       ['composer', 'require', '--dev'],
       $this->getTestingDependencies()
     ), $this->fixture->rootPath());
+    $this->commitCodeChanges('Added testing dependencies.');
   }
 
   /**

--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -63,8 +63,7 @@ class Creator {
   public function create(): void {
     $this->createBltProject();
     $this->removeUnneededProjects();
-    $this->addAcquiaProductModules();
-    $this->requireTestingDependencies();
+    $this->addAcquiaProductModuleAndTestingDependencies();
     $this->installDrupal();
     $this->installAcquiaProductModules();
     $this->createBackupBranch();
@@ -140,7 +139,7 @@ class Creator {
   /**
    * Adds Acquia product modules to the codebase.
    */
-  private function addAcquiaProductModules(): void {
+  private function addAcquiaProductModuleAndTestingDependencies(): void {
     $this->output->section('Adding Acquia product modules');
     $this->configureComposer();
     $this->requireDependencies();
@@ -224,19 +223,9 @@ class Creator {
   private function requireDependencies(): void {
     $this->processRunner->runExecutableProcess(array_merge(
       ['composer', 'require'],
-      $this->getDependencies()
-    ), $this->fixture->rootPath());
-  }
-
-  /**
-   * Requires testing dependencies via Composer.
-   */
-  private function requireTestingDependencies(): void {
-    $this->processRunner->runExecutableProcess(array_merge(
-      ['composer', 'require', '--dev'],
+      $this->getAcquiaProductModuleDependencies(),
       $this->getTestingDependencies()
     ), $this->fixture->rootPath());
-    $this->commitCodeChanges('Added testing dependencies.');
   }
 
   /**
@@ -255,11 +244,11 @@ class Creator {
   }
 
   /**
-   * Gets the list of Composer dependency strings.
+   * Gets the list of Composer dependency strings for Acquia product modules.
    *
    * @return string[]
    */
-  private function getDependencies(): array {
+  private function getAcquiaProductModuleDependencies(): array {
     $sut_package_string = "{$this->sut}:@dev";
     if ($this->isSutOnly) {
       return [$sut_package_string];
@@ -275,13 +264,11 @@ class Creator {
   }
 
   /**
-   * Gets the list of Composer testing dependency strings.
+   * Gets the list of testing dependencies.
    *
    * @return string[]
    */
   private function getTestingDependencies(): array {
-    // Add drupal-test-traits so that PHPUnit tests can be run against an
-    // installed Drupal site.
     return [
       'weitzman/drupal-test-traits:dev-master',
     ];

--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -259,6 +259,10 @@ class Creator {
       $dependencies[$this->sut] = $sut_package_string;
     }
 
+    // Add drupal-test-traits so that PHPUnit tests can be run against an
+    // installed Drupal site.
+    $dependencies['weitzman/drupal-test-traits'] = 'dev-master';
+
     return array_values($dependencies);
   }
 

--- a/src/Fixture/Creator.php
+++ b/src/Fixture/Creator.php
@@ -261,7 +261,7 @@ class Creator {
 
     // Add drupal-test-traits so that PHPUnit tests can be run against an
     // installed Drupal site.
-    $dependencies['weitzman/drupal-test-traits'] = 'dev-master';
+    $dependencies['weitzman/drupal-test-traits'] = 'weitzman/drupal-test-traits:dev-master';
 
     return array_values($dependencies);
   }

--- a/src/Task/PhpUnitTask.php
+++ b/src/Task/PhpUnitTask.php
@@ -35,8 +35,36 @@ class PhpUnitTask extends TaskBase {
     $xpath = new \DOMXPath($doc);
 
     $this->setSimpletestSettings($path, $doc, $xpath);
+    $this->enableDrupalTestTraits($path, $doc, $xpath);
     $this->disableSymfonyDeprecationsHelper($path, $doc, $xpath);
     $this->setMinkDriverArguments($path, $doc, $xpath);
+  }
+
+  /**
+   * Sets PHPUnit environment variables so that Drupal Test Traits can work.
+   *
+   * @param string $path
+   *   The path.
+   * @param \DOMDocument $doc
+   *   The DOM document.
+   * @param \DOMXPath $xpath
+   *   The XPath object.
+   */
+  private function enableDrupalTestTraits(string $path, \DOMDocument $doc, \DOMXPath $xpath): void {
+    $xpath->query('//phpunit')
+      ->item(0)
+      ->setAttribute('bootstrap', '../../vendor/weitzman/drupal-test-traits/src/bootstrap.php');
+
+    if (!$xpath->query('//phpunit/php/env[@name="DTT_BASE_URL"]')->length) {
+      $element = $doc->createElement('env');
+      $element->setAttribute('name', 'DTT_BASE_URL');
+      $element->setAttribute('value', sprintf('http://%s', Fixture::WEB_ADDRESS));
+      $xpath->query('//phpunit/php')
+        ->item(0)
+        ->appendChild($element);
+    }
+
+    $doc->save($path);
   }
 
   /**

--- a/src/Task/PhpUnitTask.php
+++ b/src/Task/PhpUnitTask.php
@@ -41,6 +41,26 @@ class PhpUnitTask extends TaskBase {
   }
 
   /**
+   * Sets Simpletest settings.
+   *
+   * @param string $path
+   *   The path.
+   * @param \DOMDocument $doc
+   *   The DOM document.
+   * @param \DOMXPath $xpath
+   *   The XPath object.
+   */
+  private function setSimpletestSettings(string $path, \DOMDocument $doc, \DOMXPath $xpath): void {
+    $xpath->query('//phpunit/php/env[@name="SIMPLETEST_BASE_URL"]')
+      ->item(0)
+      ->setAttribute('value', sprintf('http://%s', Fixture::WEB_ADDRESS));
+    $xpath->query('//phpunit/php/env[@name="SIMPLETEST_DB"]')
+      ->item(0)
+      ->setAttribute('value', 'sqlite://localhost/sites/default/files/.ht.sqlite');
+    $doc->save($path);
+  }
+
+  /**
    * Sets PHPUnit environment variables so that Drupal Test Traits can work.
    *
    * @param string $path
@@ -64,26 +84,6 @@ class PhpUnitTask extends TaskBase {
         ->appendChild($element);
     }
 
-    $doc->save($path);
-  }
-
-  /**
-   * Sets Simpletest settings.
-   *
-   * @param string $path
-   *   The path.
-   * @param \DOMDocument $doc
-   *   The DOM document.
-   * @param \DOMXPath $xpath
-   *   The XPath object.
-   */
-  private function setSimpletestSettings(string $path, \DOMDocument $doc, \DOMXPath $xpath): void {
-    $xpath->query('//phpunit/php/env[@name="SIMPLETEST_BASE_URL"]')
-      ->item(0)
-      ->setAttribute('value', sprintf('http://%s', Fixture::WEB_ADDRESS));
-    $xpath->query('//phpunit/php/env[@name="SIMPLETEST_DB"]')
-      ->item(0)
-      ->setAttribute('value', 'sqlite://localhost/sites/default/files/.ht.sqlite');
     $doc->save($path);
   }
 


### PR DESCRIPTION
Many Lightning tests (including ones that should be exposed to ORCA) use https://gitlab.com/weitzman/drupal-test-traits. This is a package which allows PHPUnit tests to be run against a pre-installed, bootstrapped Drupal -- similar to the way Behat tests already work. We should support this package by installing it when creating the fixture, and modifying the PHPUnit configuration as needed in order for the tests which use Drupal Test Traits to run properly.