### PR TITLE
Start chromedriver with additional switches

### DIFF
--- a/src/Task/PhpUnitTask.php
+++ b/src/Task/PhpUnitTask.php
@@ -130,7 +130,13 @@ class PhpUnitTask extends TaskBase {
       [
         'chrome' => [
           // Start Chrome in headless mode.
-          'switches' => ['headless', 'disable-gpu'],
+          'switches' => [
+            'headless',
+            'disable-gpu',
+            'no-sandbox',
+            'disable-dev-shm-usage',
+            'disable-extensions',
+          ],
         ],
       ],
       'http://localhost:4444',


### PR DESCRIPTION
I think that JavaScript tests which use Chromedriver are hanging on Travis CI because we are not passing the correct arguments to Chromedriver. We also need to disable certain things that are known problems when running Chromedriver on Travis CI. This PR alters the generated Mink configuration to do exactly that.