### PR TITLE
Run chromedriver during tests

### DIFF
--- a/src/Command/Tests/RunCommand.php
+++ b/src/Command/Tests/RunCommand.php
@@ -16,10 +16,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Provides a command.
  *
+ * @property \Acquia\Orca\Fixture\Chromedriver $chromedriver
  * @property \Acquia\Orca\Fixture\Fixture $fixture
  * @property \Acquia\Orca\Task\TaskRunner $taskRunner
  * @property \Acquia\Orca\Fixture\WebServer $webServer
- * @property \Acquia\Orca\Fixture\Chromedriver $chromedriver
  */
 class RunCommand extends Command {
 
@@ -30,6 +30,8 @@ class RunCommand extends Command {
    *
    * @param \Acquia\Orca\Task\BehatTask $behat
    *   The Behat task.
+   * @param \Acquia\Orca\Fixture\Chromedriver $chromedriver
+   *   The Chromedriver.
    * @param \Acquia\Orca\Fixture\Fixture $fixture
    *   The fixture.
    * @param \Acquia\Orca\Task\PhpUnitTask $phpunit
@@ -38,10 +40,8 @@ class RunCommand extends Command {
    *   The task runner.
    * @param \Acquia\Orca\Fixture\WebServer $web_server
    *   The web server.
-   * @param \Acquia\Orca\Fixture\Chromedriver $chromedriver
-   *   The chromedriver wrapper.
    */
-  public function __construct(BehatTask $behat, Fixture $fixture, PhpUnitTask $phpunit, TaskRunner $task_runner, WebServer $web_server, Chromedriver $chromedriver) {
+  public function __construct(BehatTask $behat, Chromedriver $chromedriver, Fixture $fixture, PhpUnitTask $phpunit, TaskRunner $task_runner, WebServer $web_server) {
     $this->fixture = $fixture;
     $this->taskRunner = (clone($task_runner))
       ->addTask($phpunit)
@@ -74,9 +74,11 @@ class RunCommand extends Command {
 
     $this->webServer->start();
     $this->chromedriver->start();
+
     $status_code = $this->taskRunner
       ->setPath($this->fixture->testsDirectory())
       ->run();
+
     $this->chromedriver->stop();
     $this->webServer->stop();
 

--- a/src/Command/Tests/RunCommand.php
+++ b/src/Command/Tests/RunCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Orca\Command\Tests;
 
 use Acquia\Orca\Command\StatusCodes;
+use Acquia\Orca\Fixture\Chromedriver;
 use Acquia\Orca\Fixture\Fixture;
 use Acquia\Orca\Task\BehatTask;
 use Acquia\Orca\Task\PhpUnitTask;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @property \Acquia\Orca\Fixture\Fixture $fixture
  * @property \Acquia\Orca\Task\TaskRunner $taskRunner
  * @property \Acquia\Orca\Fixture\WebServer $webServer
+ * @property \Acquia\Orca\Fixture\Chromedriver $chromedriver
  */
 class RunCommand extends Command {
 
@@ -36,13 +38,16 @@ class RunCommand extends Command {
    *   The task runner.
    * @param \Acquia\Orca\Fixture\WebServer $web_server
    *   The web server.
+   * @param \Acquia\Orca\Fixture\Chromedriver $chromedriver
+   *   The chromedriver wrapper.
    */
-  public function __construct(BehatTask $behat, Fixture $fixture, PhpUnitTask $phpunit, TaskRunner $task_runner, WebServer $web_server) {
+  public function __construct(BehatTask $behat, Fixture $fixture, PhpUnitTask $phpunit, TaskRunner $task_runner, WebServer $web_server, Chromedriver $chromedriver) {
     $this->fixture = $fixture;
     $this->taskRunner = (clone($task_runner))
       ->addTask($phpunit)
       ->addTask($behat);
     $this->webServer = $web_server;
+    $this->chromedriver = $chromedriver;
     parent::__construct(self::$defaultName);
   }
 
@@ -68,9 +73,11 @@ class RunCommand extends Command {
     }
 
     $this->webServer->start();
+    $this->chromedriver->start();
     $status_code = $this->taskRunner
       ->setPath($this->fixture->testsDirectory())
       ->run();
+    $this->chromedriver->stop();
     $this->webServer->stop();
 
     return $status_code;

--- a/src/Fixture/Chromedriver.php
+++ b/src/Fixture/Chromedriver.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Acquia\Orca\Fixture;
+
+use Acquia\Orca\ProcessRunner;
+use Symfony\Component\Process\Process;
+
+/**
+ * Provides a fixture.
+ *
+ * @property \Acquia\Orca\Fixture\Fixture $fixture
+ * @property \Acquia\Orca\ProcessRunner $processRunner
+ */
+class Chromedriver {
+
+  /**
+   * The chromedriver process.
+   *
+   * @var \Symfony\Component\Process\Process
+   */
+  private $process;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Acquia\Orca\Fixture\Fixture $fixture
+   *   The fixture.
+   * @param \Acquia\Orca\ProcessRunner $process_runner
+   *   The process runner.
+   */
+  public function __construct(Fixture $fixture, ProcessRunner $process_runner) {
+    $this->fixture = $fixture;
+    $this->processRunner = $process_runner;
+  }
+
+  /**
+   * Starts chromedriver.
+   */
+  public function start() {
+    $this->process = $this->processRunner->createOrcaVendorBinProcess([
+      'chromedriver',
+      '--port=4444',
+    ])
+      ->setTimeout(NULL)
+      ->setIdleTimeout(NULL)
+      ->start();
+    // Give the process a chance to bootstrap before releasing the thread to
+    // code that will depend on it.
+    sleep(3);
+  }
+
+  /**
+   * Stops chromedriver.
+   */
+  public function stop() {
+    if ($this->process) {
+      $this->process->stop();
+    }
+  }
+
+}

--- a/tests/Command/Tests/RunCommandTest.php
+++ b/tests/Command/Tests/RunCommandTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Orca\Tests\Command\Tests;
 
 use Acquia\Orca\Command\StatusCodes;
 use Acquia\Orca\Command\Tests\RunCommand;
+use Acquia\Orca\Fixture\Chromedriver;
 use Acquia\Orca\Fixture\Fixture;
 use Acquia\Orca\Task\BehatTask;
 use Acquia\Orca\Task\PhpUnitTask;
@@ -15,6 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Task\BehatTask $behat
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\Chromedriver $chromedriver
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\Fixture $fixture
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Task\PhpUnitTask $phpunit
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Task\TaskRunner $taskRunner
@@ -26,6 +28,7 @@ class RunCommandTest extends CommandTestBase {
 
   protected function setUp() {
     $this->behat = $this->prophesize(BehatTask::class);
+    $this->chromedriver = $this->prophesize(Chromedriver::class);
     $this->fixture = $this->prophesize(Fixture::class);
     $this->fixture->exists()
       ->willReturn(FALSE);
@@ -88,6 +91,8 @@ class RunCommandTest extends CommandTestBase {
     $application = new Application();
     /** @var \Acquia\Orca\Task\BehatTask $behat */
     $behat = $this->behat->reveal();
+    /** @var \Acquia\Orca\Fixture\Chromedriver $chromedriver */
+    $chromedriver = $this->chromedriver->reveal();
     /** @var \Acquia\Orca\Fixture\Fixture $fixture */
     $fixture = $this->fixture->reveal();
     /** @var \Acquia\Orca\Task\PhpUnitTask $phpunit */
@@ -96,7 +101,7 @@ class RunCommandTest extends CommandTestBase {
     $task_runner = $this->taskRunner->reveal();
     /** @var \Acquia\Orca\Fixture\WebServer $web_server */
     $web_server = $this->webServer->reveal();
-    $application->add(new RunCommand($behat, $fixture, $phpunit, $task_runner, $web_server));
+    $application->add(new RunCommand($behat, $chromedriver, $fixture, $phpunit, $task_runner, $web_server));
     /** @var \Acquia\Orca\Command\Tests\RunCommand $command */
     $command = $application->find(RunCommand::getDefaultName());
     $this->assertInstanceOf(RunCommand::class, $command, 'Successfully instantiated class.');


### PR DESCRIPTION
Functional JavaScript tests (e.g., anything extending WebDriverTestBase) need Chromedriver to be running in order to run at all. We are already configuring PHPUnit for this; we just need to actually, like, run Chromedriver before tests begin, and terminate it after they're done. :)