### PR TITLE
Improve how ORCA gets installed

### DIFF
--- a/bin/self-test
+++ b/bin/self-test
@@ -31,6 +31,9 @@ fi
 rm -rf ../example
 cp -R example ../
 
+# Remove dev dependencies so as to exercise ORCA as a SUT would.
+composer install --no-dev
+
 # Execute tests from the SUT directory as a SUT would.
 cd ../example
 

--- a/bin/travis/install
+++ b/bin/travis/install
@@ -59,10 +59,6 @@ composer global require \
 # Make Composer Patches throw an error when it can't apply a patch.
 export COMPOSER_EXIT_ON_PATCH_FAILURE=1
 
-# Install ORCA.
-ORCA_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-composer --no-dev -d${ORCA_ROOT} install
-
 # Ensure the checked out branch is named after the branch name argument.
 gitc rev-parse --abbrev-ref HEAD
 if [[ $(gitc rev-parse --abbrev-ref HEAD) != "$1" ]]; then

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@
 
 ORCA's primary use case is in a continuous integration workflow, running against pull requests and commits. It provides two scripts corresponding to Travis CI hooks:
 
-* **[`bin/travis/install`](../bin/travis/install)** configures the environment and installs ORCA.
+* **[`bin/travis/install`](../bin/travis/install)** configures the environment.
 * **[`bin/travis/script`](../bin/travis/script)** creates the fixtures and runs the tests.
 
 See [`example/.travis.yml`](../example/.travis.yml) for an example Travis CI configuration. Features are explained in the comments.
@@ -28,17 +28,12 @@ ORCA can also be installed and run locally for testing and development. Follow t
     PARENT_DIR="$HOME/Projects"
     ```
 
-1. Clone ORCA and your package(s) each into the directory, e.g.:
+1. Install ORCA and clone your package(s) each into the directory, e.g.:
 
     ```bash
-    git clone git@github.com:acquia/orca.git "${PARENT_DIR}/orca"
+    composer config --global repositories.orca vcs https://github.com/acquia/orca
+    composer create-project --stability=alpha --no-dev acquia/orca "${PARENT_DIR}/orca"
     git clone git@github.com:acquia/EXAMPLE.git "${PARENT_DIR}/EXAMPLE"
-    ```
-
-1. Install ORCA with Composer, e.g.:
-
-    ```bash
-    composer install --no-dev --working-dir="${PARENT_DIR}/orca"
     ```
 
 Invoke ORCA from the terminal (`bin/orca`). Use the `--help` command option to learn more about the various commands or see how they're used in [`bin/travis/script`](../bin/travis/script). Use the `fixture:run-server` command to run the web server for local development.

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   # Mark the build as finished as soon as the only remaining jobs are allowed to
   # fail.
   fast_finish: true
+
   include:
     - { name: "Static code analysis", env: ORCA_JOB=STATIC_CODE_ANALYSIS }
     - { name: "Deprecated code scan w/ SUT", env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT }
@@ -36,8 +37,15 @@ matrix:
     - env: ORCA_JOB=INTEGRATED_DEV
 
 install:
-  - "git clone --depth 1 https://github.com/acquia/orca.git ../orca"
-  # Install ORCA and prepare the environment.
+  # Install ORCA.
+  - "composer config --global repositories.orca vcs https://github.com/acquia/orca"
+  # OPTION 1: Automatically get the latest version. Available stability options
+  # are "dev", "alpha", "beta", "RC", and "stable".
+  - "composer create-project --stability=alpha --no-dev acquia/orca ../orca"
+  # OPTION 2: Pin to a specific version, e.g.:
+  # - "composer create-project --no-dev acquia/orca ../orca v1.0.0"
+
+  # Prepare the environment.
   # Supply the topic branch of the SUT to help Composer guess its version.
   - "../orca/bin/travis/install 8.x-1.x"
 


### PR DESCRIPTION
This approach allows clients to choose between always installing the latest version of ORCA at a given level of stability or pinning to a specific release. It should reduce the maintenance burden while improving stability.