### PR TITLE
Add support for automatically testing against a rolling spread of Drupal core versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
     - { name: "Integrated test w/ recommended package versions", env: ORCA_JOB=INTEGRATED_RECOMMENDED }
     - { name: "Isolated test w/ dev package versions", env: ORCA_JOB=ISOLATED_DEV }
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
+    - { name: "Previous minor version of Drupal core", env: ORCA_JOB=CORE_PREVIOUS }
+    - { name: "Next pre-release of Drupal core", env: ORCA_JOB=CORE_NEXT }
   allow_failures:
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN_CONTRIB
 

--- a/bin/travis/install.sh
+++ b/bin/travis/install.sh
@@ -24,3 +24,7 @@ assert_env_vars
 [[ "$ORCA_JOB" != "ISOLATED_DEV" ]] || ../orca fixture:init -f --sut=${ORCA_SUT_NAME} --sut-only --dev
 
 [[ "$ORCA_JOB" != "INTEGRATED_DEV" ]] || ../orca fixture:init -f --sut=${ORCA_SUT_NAME} --dev
+
+[[ "$ORCA_JOB" != "CORE_PREVIOUS" ]] || ../orca fixture:init -f --sut=${ORCA_SUT_NAME} --core=PREVIOUS_MINOR
+
+[[ "$ORCA_JOB" != "CORE_NEXT" ]] || ../orca fixture:init -f --sut=${ORCA_SUT_NAME} --core=LATEST_PRERELEASE --dev

--- a/bin/travis/script.sh
+++ b/bin/travis/script.sh
@@ -28,3 +28,7 @@ assert_env_vars
 [[ "$ORCA_JOB" != "ISOLATED_DEV" ]] || ../orca tests:run --sut=${ORCA_SUT_NAME} --sut-only
 
 [[ "$ORCA_JOB" != "INTEGRATED_DEV" ]] || ../orca tests:run --sut=${ORCA_SUT_NAME}
+
+[[ "$ORCA_JOB" != "CORE_PREVIOUS" ]] || ../orca tests:run --sut=${ORCA_SUT_NAME}
+
+[[ "$ORCA_JOB" != "CORE_NEXT" ]] || ../orca tests:run --sut=${ORCA_SUT_NAME}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/finder": "^4.1",
         "symfony/http-kernel": "^4.1",
         "symfony/options-resolver": "^4.2",
+        "symfony/phpunit-bridge": "^4.2",
         "symfony/process": "^4.1",
         "symfony/yaml": "^4.1",
         "weitzman/drupal-test-traits": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54b5b7557968e6e946210dfb4accb2a5",
+    "content-hash": "3f00d19e5cc21fa698dc6b6ecccb47ad",
     "packages": [
         {
             "name": "behat/behat",
@@ -5152,6 +5152,71 @@
                 "options"
             ],
             "time": "2019-02-23T15:17:42+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "8796da921e4613352818b478e9bb0803ea0dbb9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/8796da921e4613352818b478e9bb0803ea0dbb9a",
+                "reference": "8796da921e4613352818b478e9bb0803ea0dbb9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2019-03-26T20:16:42+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/config/services.yml
+++ b/config/services.yml
@@ -6,17 +6,12 @@ parameters:
   env(ORCA_PACKAGES_CONFIG): config/packages.yml
   env(ORCA_PACKAGES_CONFIG_ALTER): ~
 
-  # Static configuration:
-  drupal_core_dev_version: 8.6.x-dev
-
 services:
 
   _defaults:
     autoconfigure: true
     autowire: true
     bind:
-      $drupal_core_dev_version: "%drupal_core_dev_version%"
-      $drupal_core_version: "%drupal_core_dev_version%"
       $fixture_dir: "%env(ORCA_FIXTURE_DIR)%"
       $project_dir: "%kernel.project_dir%"
       $packages_config: "%env(ORCA_PACKAGES_CONFIG)%"

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -36,11 +36,14 @@ matrix:
     - { name: "Integrated test w/ recommended package versions", env: ORCA_JOB=INTEGRATED_RECOMMENDED }
     - { name: "Isolated test w/ dev package versions", env: ORCA_JOB=ISOLATED_DEV }
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
+    - { name: "Previous minor version of Drupal core", env: ORCA_JOB=CORE_PREVIOUS }
+    - { name: "Next pre-release of Drupal core", env: ORCA_JOB=CORE_NEXT }
   allow_failures:
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN_CONTRIB
     - env: ORCA_JOB=ISOLATED_DEV
     - env: ORCA_JOB=INTEGRATED_DEV
+    - env: ORCA_JOB=CORE_NEXT
 
 # Install ORCA and prepare the environment.
 before_install:

--- a/src/Command/Fixture/FixtureInitCommand.php
+++ b/src/Command/Fixture/FixtureInitCommand.php
@@ -8,6 +8,7 @@ use Acquia\Orca\Fixture\FixtureCreator;
 use Acquia\Orca\Fixture\PackageManager;
 use Acquia\Orca\Fixture\FixtureRemover;
 use Acquia\Orca\Fixture\Fixture;
+use Acquia\Orca\Utility\DrupalCoreVersionFinder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,6 +25,13 @@ class FixtureInitCommand extends Command {
    * @var string
    */
   protected static $defaultName = 'fixture:init';
+
+  /**
+   * The Drupal core version finder.
+   *
+   * @var \Acquia\Orca\Utility\DrupalCoreVersionFinder
+   */
+  private $drupalCoreVersionFinder;
 
   /**
    * The fixture.
@@ -56,6 +64,8 @@ class FixtureInitCommand extends Command {
   /**
    * Constructs an instance.
    *
+   * @param \Acquia\Orca\Utility\DrupalCoreVersionFinder $drupal_core_version_finder
+   *   The Drupal core version finder.
    * @param \Acquia\Orca\Fixture\Fixture $fixture
    *   The fixture.
    * @param \Acquia\Orca\Fixture\FixtureCreator $fixture_creator
@@ -65,7 +75,8 @@ class FixtureInitCommand extends Command {
    * @param \Acquia\Orca\Fixture\PackageManager $package_manager
    *   The package manager.
    */
-  public function __construct(Fixture $fixture, FixtureCreator $fixture_creator, FixtureRemover $fixture_remover, PackageManager $package_manager) {
+  public function __construct(DrupalCoreVersionFinder $drupal_core_version_finder, Fixture $fixture, FixtureCreator $fixture_creator, FixtureRemover $fixture_remover, PackageManager $package_manager) {
+    $this->drupalCoreVersionFinder = $drupal_core_version_finder;
     $this->fixtureCreator = $fixture_creator;
     $this->fixture = $fixture;
     $this->packageManager = $package_manager;
@@ -83,8 +94,15 @@ class FixtureInitCommand extends Command {
       ->setHelp('Creates a BLT-based Drupal site build, includes the system under test using Composer, optionally includes all other Acquia packages, and installs Drupal.')
       ->addOption('sut', NULL, InputOption::VALUE_REQUIRED, 'The system under test (SUT) in the form of its package name, e.g., "drupal/example"')
       ->addOption('sut-only', NULL, InputOption::VALUE_NONE, 'Add only the system under test (SUT). Omit all other non-required Acquia packages')
-      ->addOption('core', NULL, InputOption::VALUE_REQUIRED, 'Change the version of Drupal core installed, e.g., "8.6.0", "~8.6", or "8.6.x-dev"')
-      ->addOption('dev', NULL, InputOption::VALUE_NONE, 'Use dev (HEAD) branches instead of stable releases of Drupal core and Acquia packages')
+      ->addOption('core', NULL, InputOption::VALUE_REQUIRED, implode(PHP_EOL, [
+        'Change the version of Drupal core installed:',
+        '- PREVIOUS_MINOR: The latest stable release of the previous minor version, e.g., "8.5.14" if the current minor version is "8.6"',
+        '- CURRENT_RECOMMENDED: The current recommended release, e.g., "8.6.14"',
+        '- CURRENT_DEV: The current development version, e.g., "8.6.x-dev"',
+        '- LATEST_PRERELEASE: The latest pre-release version, e.g., "8.7.0-beta2". Note: This could be newer OR older than the current recommended release',
+        '- Any version string Composer understands, see https://getcomposer.org/doc/articles/versions.md',
+      ]))
+      ->addOption('dev', NULL, InputOption::VALUE_NONE, 'Use dev versions of Acquia packages')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'If the fixture already exists, remove it first without confirmation')
       ->addOption('profile', NULL, InputOption::VALUE_REQUIRED, 'The Drupal installation profile to use, e.g., "lightning"', FixtureCreator::DEFAULT_PROFILE)
       ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default BLT database includes instead of SQLite');
@@ -118,7 +136,7 @@ class FixtureInitCommand extends Command {
     $this->setSut($sut);
     $this->setSutOnly($sut_only);
     $this->setDev($input->getOption('dev'));
-    $this->setCore($input->getOption('core'));
+    $this->setCore($input->getOption('core'), $input->getOption('dev'));
     $this->setProfile($input->getOption('profile'));
     $this->setSqlite($input->getOption('no-sqlite'));
 
@@ -203,11 +221,36 @@ class FixtureInitCommand extends Command {
    *
    * @param string|string[]|bool|null $version
    *   The version string.
+   * @param string|string[]|bool|null $dev
+   *   The dev flag.
    */
-  private function setCore($version): void {
-    if ($version) {
-      $this->fixtureCreator->setCoreVersion($version);
+  private function setCore($version, $dev): void {
+    if ($dev && !$version) {
+      $version = 'CURRENT_DEV';
     }
+
+    if (!$version) {
+      return;
+    }
+
+    switch ($version) {
+      case 'PREVIOUS_MINOR':
+        $version = $this->drupalCoreVersionFinder->getPreviousMinorVersion();
+        break;
+
+      case 'CURRENT_RECOMMENDED':
+        $version = $this->drupalCoreVersionFinder->getCurrentRecommendedVersion();
+        break;
+
+      case 'CURRENT_DEV':
+        $version = $this->drupalCoreVersionFinder->getCurrentDevVersion();
+        break;
+
+      case 'LATEST_PRERELEASE':
+        $version = $this->drupalCoreVersionFinder->getLatestPreReleaseVersion();
+        break;
+    }
+    $this->fixtureCreator->setCoreVersion($version);
   }
 
   /**

--- a/src/Utility/DrupalCoreVersionFinder.php
+++ b/src/Utility/DrupalCoreVersionFinder.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Acquia\Orca\Utility;
+
+use Composer\DependencyResolver\Pool;
+use Composer\IO\NullIO;
+use Composer\Package\Version\VersionSelector;
+use Composer\Repository\RepositoryFactory;
+
+/**
+ * Finds a range of Drupal core versions.
+ */
+class DrupalCoreVersionFinder {
+
+  /**
+   * The current recommended version.
+   *
+   * @var string
+   */
+  private $currentRecommendedVersion = '';
+
+  /**
+   * The latest pre-release version.
+   *
+   * @var string
+   */
+  private $latestPreReleaseVersion = '';
+
+  /**
+   * The previous minor version.
+   *
+   * @var string
+   */
+  private $previousMinorVersion = '';
+
+  /**
+   * Gets the previous minor version.
+   *
+   * @return string
+   *   The version string, e.g., "8.5.14.0".
+   */
+  public function getPreviousMinorVersion(): string {
+    if ($this->previousMinorVersion) {
+      return $this->previousMinorVersion;
+    }
+    $this->previousMinorVersion = $this->getVersionSelector()
+      ->findBestCandidate('drupal/core', "<{$this->getCurrentMinorVersion()}")
+      ->getVersion();
+    return $this->previousMinorVersion;
+  }
+
+  /**
+   * Gets the current recommended version.
+   *
+   * @return string
+   *   The version string, e.g., "8.6.14.0".
+   */
+  public function getCurrentRecommendedVersion(): string {
+    if ($this->currentRecommendedVersion) {
+      return $this->currentRecommendedVersion;
+    }
+    $this->currentRecommendedVersion = $this->getVersionSelector()
+      ->findBestCandidate('drupal/core')
+      ->getVersion();
+    return $this->currentRecommendedVersion;
+  }
+
+  /**
+   * Gets the current dev version.
+   *
+   * @return string
+   *   The version string, e.g., "8.6.x-dev".
+   */
+  public function getCurrentDevVersion(): string {
+    return "{$this->getCurrentMinorVersion()}.x-dev";
+  }
+
+  /**
+   * Gets the latest pre-release version.
+   *
+   * @return string
+   *   The version string, e.g., "8.7.0.0-beta2".
+   */
+  public function getLatestPreReleaseVersion(): string {
+    if ($this->latestPreReleaseVersion) {
+      return $this->latestPreReleaseVersion;
+    }
+    $this->latestPreReleaseVersion = $this->getVersionSelector('alpha')
+      ->findBestCandidate('drupal/core', ">{$this->getCurrentRecommendedVersion()}")
+      ->getVersion();
+    return $this->latestPreReleaseVersion;
+  }
+
+  /**
+   * Gets a Composer version selector.
+   *
+   * @param string $minimum_stability
+   *   The minimum stability. Available options (in order of stability) are
+   *   dev, alpha, beta, RC, and stable.
+   *
+   * @return \Composer\Package\Version\VersionSelector
+   *   A Composer version selector.
+   */
+  private function getVersionSelector($minimum_stability = 'stable'): VersionSelector {
+    $pool = new Pool($minimum_stability);
+    $packagist = RepositoryFactory::defaultRepos(new NullIO())['packagist.org'];
+    $pool->addRepository($packagist);
+    return new VersionSelector($pool);
+  }
+
+  /**
+   * Gets the current minor version.
+   *
+   * @return string
+   *   The version string, e.g., "8.6".
+   */
+  private function getCurrentMinorVersion(): string {
+    return (string) floatval($this->getCurrentRecommendedVersion());
+  }
+
+}

--- a/tests/Command/Fixture/FixtureInitCommandTest.php
+++ b/tests/Command/Fixture/FixtureInitCommandTest.php
@@ -10,10 +10,12 @@ use Acquia\Orca\Fixture\FixtureRemover;
 use Acquia\Orca\Fixture\Fixture;
 use Acquia\Orca\Fixture\FixtureCreator;
 use Acquia\Orca\Tests\Command\CommandTestBase;
+use Acquia\Orca\Utility\DrupalCoreVersionFinder;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Utility\DrupalCoreVersionFinder $drupalCoreVersionFinder
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\Fixture $fixture
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\FixtureCreator $fixtureCreator
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\FixtureRemover $fixtureRemover
@@ -21,9 +23,12 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class FixtureInitCommandTest extends CommandTestBase {
 
-  private const DRUPAL_CORE_VERSION = '8.6.0';
+  private const DRUPAL_CORE_RECOMMENDED_VERSION = '8.6.14.0';
+
+  private const DRUPAL_CORE_DEV_VERSION = '8.6.x-dev';
 
   protected function setUp() {
+    $this->drupalCoreVersionFinder = $this->prophesize(DrupalCoreVersionFinder::class);
     $this->fixtureCreator = $this->prophesize(FixtureCreator::class);
     $this->fixtureRemover = $this->prophesize(FixtureRemover::class);
     $this->fixture = $this->prophesize(Fixture::class);
@@ -37,7 +42,7 @@ class FixtureInitCommandTest extends CommandTestBase {
   /**
    * @dataProvider providerCommand
    */
-  public function testCommand($fixture_exists, $args, $methods_called, $exception, $status_code, $display) {
+  public function testCommand($fixture_exists, $args, $methods_called, $drupal_core_version, $exception, $status_code, $display) {
     $this->packageManager
       ->exists(@$args['--sut'])
       ->shouldBeCalledTimes((int) in_array('PackageManager::exists', $methods_called))
@@ -49,6 +54,22 @@ class FixtureInitCommandTest extends CommandTestBase {
     $this->fixtureRemover
       ->remove()
       ->shouldBeCalledTimes((int) in_array('remove', $methods_called));
+    $this->drupalCoreVersionFinder
+      ->getPreviousMinorVersion()
+      ->shouldBeCalledTimes((int) in_array('getPreviousMinorVersion', $methods_called))
+      ->willReturn($drupal_core_version);
+    $this->drupalCoreVersionFinder
+      ->getCurrentRecommendedVersion()
+      ->shouldBeCalledTimes((int) in_array('getCurrentRecommendedVersion', $methods_called))
+      ->willReturn(self::DRUPAL_CORE_RECOMMENDED_VERSION);
+    $this->drupalCoreVersionFinder
+      ->getCurrentDevVersion()
+      ->shouldBeCalledTimes((int) in_array('getCurrentDevVersion', $methods_called))
+      ->willReturn($drupal_core_version);
+    $this->drupalCoreVersionFinder
+      ->getLatestPreReleaseVersion()
+      ->shouldBeCalledTimes((int) in_array('getLatestPreReleaseVersion', $methods_called))
+      ->willReturn($drupal_core_version);
     $this->fixtureCreator
       ->setSut(@$args['--sut'])
       ->shouldBeCalledTimes((int) in_array('setSut', $methods_called));
@@ -59,7 +80,7 @@ class FixtureInitCommandTest extends CommandTestBase {
       ->setDev(TRUE)
       ->shouldBeCalledTimes((int) in_array('setDev', $methods_called));
     $this->fixtureCreator
-      ->setCoreVersion(self::DRUPAL_CORE_VERSION)
+      ->setCoreVersion($drupal_core_version ?: self::DRUPAL_CORE_RECOMMENDED_VERSION)
       ->shouldBeCalledTimes((int) in_array('setCoreVersion', $methods_called));
     $this->fixtureCreator
       ->setSqlite(FALSE)
@@ -85,23 +106,29 @@ class FixtureInitCommandTest extends CommandTestBase {
 
   public function providerCommand() {
     return [
-      [TRUE, [], ['Fixture::exists'], 0, StatusCodes::ERROR, sprintf("Error: Fixture already exists at %s.\nHint: Use the \"--force\" option to remove it and proceed.\n", self::FIXTURE_ROOT)],
-      [TRUE, ['-f' => TRUE], ['Fixture::exists', 'remove', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, [], ['Fixture::exists', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--sut' => self::INVALID_PACKAGE], ['PackageManager::exists'], 0, StatusCodes::ERROR, sprintf("Error: Invalid value for \"--sut\" option: \"%s\".\n", self::INVALID_PACKAGE)],
-      [FALSE, ['--sut' => self::VALID_PACKAGE], ['PackageManager::exists', 'Fixture::exists', 'create', 'setSut'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--sut' => self::VALID_PACKAGE, '--sut-only' => TRUE], ['PackageManager::exists', 'Fixture::exists', 'create', 'setSut', 'setSutOnly'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--core' => self::DRUPAL_CORE_VERSION], ['Fixture::exists', 'setCoreVersion', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--dev' => TRUE], ['Fixture::exists', 'setDev', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--no-sqlite' => TRUE], ['Fixture::exists', 'setSqlite', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, ['--profile' => 'lightning'], ['Fixture::exists', 'setProfile', 'create'], 0, StatusCodes::OK, ''],
-      [FALSE, [], ['Fixture::exists', 'create'], 1, StatusCodes::ERROR, ''],
-      [FALSE, ['--sut-only' => TRUE], [], 0, StatusCodes::ERROR, "Error: Cannot create a SUT-only fixture without a SUT.\nHint: Use the \"--sut\" option to specify the SUT.\n"],
+      [TRUE, [], ['Fixture::exists'], NULL, 0, StatusCodes::ERROR, sprintf("Error: Fixture already exists at %s.\nHint: Use the \"--force\" option to remove it and proceed.\n", self::FIXTURE_ROOT)],
+      [TRUE, ['-f' => TRUE], ['Fixture::exists', 'remove', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, [], ['Fixture::exists', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--sut' => self::INVALID_PACKAGE], ['PackageManager::exists'], NULL, 0, StatusCodes::ERROR, sprintf("Error: Invalid value for \"--sut\" option: \"%s\".\n", self::INVALID_PACKAGE)],
+      [FALSE, ['--sut' => self::VALID_PACKAGE], ['PackageManager::exists', 'Fixture::exists', 'create', 'setSut'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--sut' => self::VALID_PACKAGE, '--sut-only' => TRUE], ['PackageManager::exists', 'Fixture::exists', 'create', 'setSut', 'setSutOnly'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--core' => 'PREVIOUS_MINOR'], ['Fixture::exists', 'getPreviousMinorVersion', 'setCoreVersion', 'create'], '8.5.14.0', 0, StatusCodes::OK, ''],
+      [FALSE, ['--core' => 'CURRENT_RECOMMENDED'], ['Fixture::exists', 'getCurrentRecommendedVersion', 'setCoreVersion', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--core' => 'CURRENT_DEV'], ['Fixture::exists', 'getCurrentDevVersion', 'setCoreVersion', 'create'], '8.5.x-dev', 0, StatusCodes::OK, ''],
+      [FALSE, ['--core' => 'LATEST_PRERELEASE'], ['Fixture::exists', 'getLatestPreReleaseVersion', 'setCoreVersion', 'create'], '8.7.0.0-beta2', 0, StatusCodes::OK, ''],
+      [FALSE, ['--core' => 'CURRENT_RECOMMENDED', '--dev' => TRUE], ['Fixture::exists', 'setDev', 'getCurrentRecommendedVersion', 'setCoreVersion', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--dev' => TRUE], ['Fixture::exists', 'setDev', 'getCurrentDevVersion', 'setCoreVersion', 'create'], self::DRUPAL_CORE_DEV_VERSION, 0, StatusCodes::OK, ''],
+      [FALSE, ['--no-sqlite' => TRUE], ['Fixture::exists', 'setSqlite', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, ['--profile' => 'lightning'], ['Fixture::exists', 'setProfile', 'create'], NULL, 0, StatusCodes::OK, ''],
+      [FALSE, [], ['Fixture::exists', 'create'], NULL, 1, StatusCodes::ERROR, ''],
+      [FALSE, ['--sut-only' => TRUE], [], NULL, 0, StatusCodes::ERROR, "Error: Cannot create a SUT-only fixture without a SUT.\nHint: Use the \"--sut\" option to specify the SUT.\n"],
     ];
   }
 
   private function createCommandTester(): CommandTester {
     $application = new Application();
+    /** @var \Acquia\Orca\Utility\DrupalCoreVersionFinder $drupal_core_version_finder */
+    $drupal_core_version_finder = $this->drupalCoreVersionFinder->reveal();
     /** @var \Acquia\Orca\Fixture\FixtureCreator $fixture_creator */
     $fixture_creator = $this->fixtureCreator->reveal();
     /** @var \Acquia\Orca\Fixture\FixtureRemover $fixture_remover */
@@ -110,7 +137,7 @@ class FixtureInitCommandTest extends CommandTestBase {
     $fixture = $this->fixture->reveal();
     /** @var \Acquia\Orca\Fixture\PackageManager $package_manager */
     $package_manager = $this->packageManager->reveal();
-    $application->add(new FixtureInitCommand($fixture, $fixture_creator, $fixture_remover, $package_manager));
+    $application->add(new FixtureInitCommand($drupal_core_version_finder, $fixture, $fixture_creator, $fixture_remover, $package_manager));
     /** @var \Acquia\Orca\Command\Fixture\FixtureInitCommand $command */
     $command = $application->find(FixtureInitCommand::getDefaultName());
     $this->assertInstanceOf(FixtureInitCommand::class, $command, 'Instantiated class.');


### PR DESCRIPTION
This adds automatic, rolling, testing against four versions of Drupal core:
- The latest stable release of the previous minor version, e.g., "8.5.14" if the current minor version is "8.6"
- The current recommended release, e.g., "8.6.14"
- The current development version, e.g., "8.6.x-dev"
- The latest pre-release version, e.g., "8.7.0-beta2"

Corresponding new Travis CI jobs are available and documented in `example/.travis.yml`.