### PR TITLE
Add fixture:init --no-site-install option to skip Drupal site installation

### DIFF
--- a/src/Command/Fixture/FixtureInitCommand.php
+++ b/src/Command/Fixture/FixtureInitCommand.php
@@ -105,7 +105,8 @@ class FixtureInitCommand extends Command {
       ->addOption('dev', NULL, InputOption::VALUE_NONE, 'Use dev versions of Acquia packages')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'If the fixture already exists, remove it first without confirmation')
       ->addOption('profile', NULL, InputOption::VALUE_REQUIRED, 'The Drupal installation profile to use, e.g., "lightning"', FixtureCreator::DEFAULT_PROFILE)
-      ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default BLT database includes instead of SQLite');
+      ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default BLT database includes instead of SQLite')
+      ->addOption('no-site-install', NULL, InputOption::VALUE_NONE, 'Do not install Drupal. Supersedes the "--profile" option');
   }
 
   /**
@@ -138,6 +139,7 @@ class FixtureInitCommand extends Command {
     $this->setDev($input->getOption('dev'));
     $this->setCore($input->getOption('core'), $input->getOption('dev'));
     $this->setProfile($input->getOption('profile'));
+    $this->setSiteInstall($input->getOption('no-site-install'));
     $this->setSqlite($input->getOption('no-sqlite'));
 
     try {
@@ -262,6 +264,18 @@ class FixtureInitCommand extends Command {
   private function setProfile($profile): void {
     if ($profile !== FixtureCreator::DEFAULT_PROFILE) {
       $this->fixtureCreator->setProfile($profile);
+    }
+  }
+
+  /**
+   * Sets the site install flag.
+   *
+   * @param string|string[]|bool|null $no_site_install
+   *   The no-site-install flag.
+   */
+  private function setSiteInstall($no_site_install) {
+    if ($no_site_install) {
+      $this->fixtureCreator->setInstallSite(FALSE);
     }
   }
 

--- a/tests/Command/Fixture/FixtureInitCommandTest.php
+++ b/tests/Command/Fixture/FixtureInitCommandTest.php
@@ -89,6 +89,9 @@ class FixtureInitCommandTest extends CommandTestBase {
       ->setProfile((@$args['--profile']) ?: 'minimal')
       ->shouldBeCalledTimes((int) in_array('setProfile', $methods_called));
     $this->fixtureCreator
+      ->setInstallSite(FALSE)
+      ->shouldBeCalledTimes((int) in_array('setInstallSite', $methods_called));
+    $this->fixtureCreator
       ->create()
       ->shouldBeCalledTimes((int) in_array('create', $methods_called));
     if ($exception) {
@@ -118,6 +121,7 @@ class FixtureInitCommandTest extends CommandTestBase {
       [FALSE, ['--core' => 'LATEST_PRERELEASE'], ['Fixture::exists', 'getLatestPreReleaseVersion', 'setCoreVersion', 'create'], '8.7.0.0-beta2', 0, StatusCodes::OK, ''],
       [FALSE, ['--core' => 'CURRENT_RECOMMENDED', '--dev' => TRUE], ['Fixture::exists', 'setDev', 'getCurrentRecommendedVersion', 'setCoreVersion', 'create'], NULL, 0, StatusCodes::OK, ''],
       [FALSE, ['--dev' => TRUE], ['Fixture::exists', 'setDev', 'getCurrentDevVersion', 'setCoreVersion', 'create'], self::DRUPAL_CORE_DEV_VERSION, 0, StatusCodes::OK, ''],
+      [FALSE, ['--no-site-install' => TRUE], ['Fixture::exists', 'setInstallSite', 'create'], NULL, 0, StatusCodes::OK, ''],
       [FALSE, ['--no-sqlite' => TRUE], ['Fixture::exists', 'setSqlite', 'create'], NULL, 0, StatusCodes::OK, ''],
       [FALSE, ['--profile' => 'lightning'], ['Fixture::exists', 'setProfile', 'create'], NULL, 0, StatusCodes::OK, ''],
       [FALSE, [], ['Fixture::exists', 'create'], NULL, 1, StatusCodes::ERROR, ''],


### PR DESCRIPTION
This option is valuable for automated tests that use a database import and thus waste time installing the site only to overwrite it immediately. It is also useful for tests or users who wish to use the install wizard. It can save more than a minute of processing time in these cases.