### PR TITLE
Change SUT repository from "path" to "package" type for more robustness when developing locally

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -456,8 +456,18 @@ class FixtureCreator {
 
     // Add new repository.
     $this->jsonConfigSource->addRepository($this->sut->getPackageName(), [
-      'type' => 'path',
-      'url' => $this->fixture->getPath($this->sut->getRepositoryUrl()),
+      'type' => 'package',
+      'package' => [
+        [
+          'name' => $this->sut->getPackageName(),
+          'version' => $this->getSutVersion(),
+          'type' => $this->sut->getType(),
+          'dist' => [
+            'type' => 'path',
+            'url' => $this->fixture->getPath($this->sut->getRepositoryUrl()),
+          ],
+        ],
+      ],
     ]);
 
     // Append original repositories.


### PR DESCRIPTION
Composer path repositories work well for placing the SUT on Travis CI where the checked out Git branch gets renamed to match the target branch (i.e., `ORCA_SUT_BRANCH`), but developing locally with arbitrary topic branches checked out branch can lead to unexpected failures like "Could not find package drupal/example in a version matching dev-my-topic-branch". A package repository using whatever Composer considers the local repo's version supports this use case without changing the behavior on Travis CI.