### PR TITLE
Fix ChromeDriver failures

### DIFF
--- a/bin/travis/_includes.sh
+++ b/bin/travis/_includes.sh
@@ -42,6 +42,9 @@ export ORCA_AMPLITUDE_USER_ID=${ORCA_AMPLITUDE_USER_ID:="$ORCA_SUT_NAME:$ORCA_SU
 # too narrowly.
 export COLUMNS=125
 
+# Correct Selenium URL for new versions of Chrome/ChromeDriver:
+export BEHAT_PARAMS='{"extensions":{"Behat\\MinkExtension":{"selenium2":{"wd_host":"http://127.0.0.1:4444","capabilities":{"chrome":{"switches":["--headless","--disable-gpu"]}}}}}}'
+
 # Add binary directories to PATH.
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export PATH="$ORCA_ROOT/bin:$PATH"

--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,6 @@
         "sort-packages": true
     },
     "extra": {
-        "chromedriver": {
-            "version": "74.0.3729.6"
-        },
         "hooks": {
             "pre-commit": [
                 "set -e",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f80e6563f6de38f0e16177819a439a01",
+    "content-hash": "6c493ba50e4829f182072fc579cc82fa",
     "packages": [
         {
             "name": "acquia/coding-standards",

--- a/example/behat.yml
+++ b/example/behat.yml
@@ -3,7 +3,7 @@ default:
   suites:
     default:
       paths:
-        - 'docroot/modules/contrib/example/tests/features'
+        - docroot/modules/contrib/example/tests/features
       contexts:
         - Drupal\example\tests\FeatureContext
         - Drupal\DrupalExtension\Context\DrupalContext
@@ -12,8 +12,17 @@ default:
         - Drupal\DrupalExtension\Context\DrushContext
   extensions:
     Behat\MinkExtension:
+      base_url: "http://127.0.0.1:8080"
       goutte: ~
-      selenium2: ~
-      base_url: "http://127.0.0.1:8080/"
+      selenium2:
+        wd_host: "http://127.0.0.1:4444"
+        capabilities:
+          chrome:
+            switches:
+              - "--headless"
+              - "--disable-gpu"
     Drupal\DrupalExtension:
       blackbox: ~
+      api_driver: drupal
+      drupal:
+        drupal_root: docroot

--- a/example/tests/features/example.feature
+++ b/example/tests/features/example.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Example
   In order to prove that ORCA works properly and demonstrate how to use it
   As a project maintainer
@@ -13,3 +14,9 @@ Feature: Example
     Given I tag a scenario @orca_ignore
     When I run ORCA tests
     Then the tagged scenario should not be run
+
+  @javascript
+  Scenario: Exercising ChromeDriver
+    Given I am logged in as a user with the "authenticated user" role
+    And I visit the homepage
+    Then I should get an HTTP 200 status code


### PR DESCRIPTION
Fixes: #37 

ChromeDrivers resulting from [version 75 enforcing w3c compliance mode](https://medium.com/@alex.designworks/chromedriver-75-enforces-w3c-standard-breaking-behat-tests-460cad435545) were previously worked around by pinning to a specific version. However, the version of Chrome installed on Travis CI as of this week is not compatible with that version of ChromeDriver, so tests began failing again when it changed.

This PR unpins the ChromeDriver version and fixes the resulting errors with Behat parameters.