### PR TITLE
Use Seven as the admin theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "behat/behat": "^3.5",
         "composer/composer": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "hassankhan/config": "^2.0",
+        "hassankhan/config": "^2.1",
         "jakub-onderka/php-console-highlighter": "^0.4.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "localheinz/composer-normalize": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a664218c77b7351ad6825a259b092aef",
+    "content-hash": "d68590d14e045343a7af5c02238212da",
     "packages": [
         {
             "name": "acquia/coding-standards",
@@ -1195,16 +1195,16 @@
         },
         {
             "name": "hassankhan/config",
-            "version": "2.0.2",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hassankhan/config.git",
-                "reference": "d30cdc72d37a592e856e9f1b62e29a03b049d785"
+                "reference": "16fa4d3320ac9bb611dda0c8ea980edb58d227c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hassankhan/config/zipball/d30cdc72d37a592e856e9f1b62e29a03b049d785",
-                "reference": "d30cdc72d37a592e856e9f1b62e29a03b049d785",
+                "url": "https://api.github.com/repos/hassankhan/config/zipball/16fa4d3320ac9bb611dda0c8ea980edb58d227c9",
+                "reference": "16fa4d3320ac9bb611dda0c8ea980edb58d227c9",
                 "shasum": ""
             },
             "require": {
@@ -1249,7 +1249,7 @@
                 "yaml",
                 "yml"
             ],
-            "time": "2019-04-06T17:34:30+00:00"
+            "time": "2019-09-01T15:51:42+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",

--- a/src/Fixture/AcquiaExtensionEnabler.php
+++ b/src/Fixture/AcquiaExtensionEnabler.php
@@ -170,7 +170,6 @@ class AcquiaExtensionEnabler {
     $this->processRunner->runFixtureVendorBin([
       'drush',
       'theme:enable',
-      '--yes',
       implode(',', $theme_list),
     ]);
   }

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -25,7 +25,7 @@ class FixtureCreator {
 
   use SutSettingsTrait;
 
-  const DEFAULT_PROFILE = 'minimal';
+  const DEFAULT_PROFILE = 'testing';
 
   /**
    * The Composer exit on patch failure flag.

--- a/src/Fixture/SiteInstaller.php
+++ b/src/Fixture/SiteInstaller.php
@@ -3,7 +3,12 @@
 namespace Acquia\Orca\Fixture;
 
 use Acquia\Orca\Utility\ProcessRunner;
+use Noodlehaus\Config;
+use Noodlehaus\Writer\Yaml;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
  * Installs a site and enables Acquia extensions.
@@ -16,6 +21,13 @@ class SiteInstaller {
    * @var \Acquia\Orca\Fixture\AcquiaExtensionEnabler
    */
   private $acquiaExtensionEnabler;
+
+  /**
+   * The filesystem.
+   *
+   * @var \Symfony\Component\Filesystem\Filesystem
+   */
+  private $filesystem;
 
   /**
    * The fixture.
@@ -39,22 +51,56 @@ class SiteInstaller {
   private $processRunner;
 
   /**
+   * The profile to install.
+   *
+   * @var string|null
+   */
+  private $profile;
+
+  /**
+   * The path the Testing profile is backed up to.
+   *
+   * @var string|null
+   */
+  private $profileBackupPath;
+
+  /**
+   * The path of the Testing profile.
+   *
+   * @var string|null
+   */
+  private $profilePath;
+
+  /**
+   * The ORCA project directory.
+   *
+   * @var string
+   */
+  private $projectDir;
+
+  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Fixture\AcquiaExtensionEnabler $acquia_extension_enabler
    *   The Acquia extension enabler.
+   * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+   *   The filesystem.
    * @param \Acquia\Orca\Fixture\Fixture $fixture
    *   The fixture.
    * @param \Acquia\Orca\Utility\ProcessRunner $process_runner
    *   The process runner.
+   * @param string $project_dir
+   *   The ORCA project directory.
    * @param \Symfony\Component\Console\Style\SymfonyStyle $output
    *   The output decorator.
    */
-  public function __construct(AcquiaExtensionEnabler $acquia_extension_enabler, Fixture $fixture, ProcessRunner $process_runner, SymfonyStyle $output) {
+  public function __construct(AcquiaExtensionEnabler $acquia_extension_enabler, Filesystem $filesystem, Fixture $fixture, ProcessRunner $process_runner, string $project_dir, SymfonyStyle $output) {
     $this->acquiaExtensionEnabler = $acquia_extension_enabler;
+    $this->filesystem = $filesystem;
     $this->fixture = $fixture;
     $this->output = $output;
     $this->processRunner = $process_runner;
+    $this->projectDir = $project_dir;
   }
 
   /**
@@ -66,22 +112,108 @@ class SiteInstaller {
    * @throws \Exception
    */
   public function install(string $profile): void {
-    $this->installDrupal($profile);
-    $this->acquiaExtensionEnabler->enable();
+    $this->profile = $profile;
+    $this->prepareTestingProfile();
+    $this->installDrupal();
+    $this->restoreTestingProfile();
+    $this->enableExtensions();
+  }
+
+  /**
+   * Prepares the Testing profile for installation.
+   *
+   * Augments the Testing profile, if selected, with some basic theme settings
+   * from Standard.
+   */
+  private function prepareTestingProfile(): void {
+    if (!$this->isTestingProfile()) {
+      return;
+    }
+
+    $this->backupTestingProfile();
+    $this->addDependencies();
+    $this->copyStandardThemeSettings();
+  }
+
+  /**
+   * Determines whether or not the Testing profile is being installed.
+   *
+   * @return bool
+   *   TRUE if the Testing profile is being installed or FALSE if not.
+   */
+  private function isTestingProfile(): bool {
+    return $this->profile === 'testing';
+  }
+
+  /**
+   * Backs up the Testing profile.
+   */
+  private function backupTestingProfile(): void {
+    $this->profilePath = $this->fixture->getPath('docroot/core/profiles/testing');
+    $this->profileBackupPath = sprintf('%s/var/backup/testing-%s', $this->projectDir, uniqid());
+    $this->filesystem->mirror($this->profilePath, $this->profileBackupPath);
+  }
+
+  /**
+   * Adds dependencies to the Testing profile.
+   */
+  private function addDependencies(): void {
+    $path = $this->fixture->getPath('docroot/core/profiles/testing/testing.info.yml');
+    $info_file = (Config::load($path));
+
+    $this->addItems($info_file, 'install', ['block', 'help', 'toolbar']);
+    $this->addItems($info_file, 'themes', ['seven']);
+
+    $info_file->toFile($path, new Yaml());
+  }
+
+  /**
+   * Adds items to a given config file key value.
+   *
+   * @param \Noodlehaus\Config $file
+   *   The config file.
+   * @param string $key
+   *   The key.
+   * @param string[] $items
+   *   The items to add.
+   */
+  private function addItems(Config $file, string $key, array $items): void {
+    $original_value = $file->get($key, []);
+    $value = array_merge($original_value, $items);
+    $file->set($key, $value);
+  }
+
+  /**
+   * Copies the theme and block settings from the Standard profile to Testing.
+   */
+  private function copyStandardThemeSettings(): void {
+    // Ensure no theme settings in the install config conflict with those about
+    // to be copied into the optional config.
+    $this->filesystem->remove($this->fixture->getPath('docroot/core/profiles/testing/config/install/system.theme.yml'));
+
+    $files = (new Finder())
+      ->files()
+      ->in($this->fixture->getPath('docroot/core/profiles/standard/config/install'))
+      ->name([
+        '/block.block.seven_.*\.yml/',
+        'system.theme.yml',
+      ]);
+    /** @var \SplFileInfo $file */
+    foreach ($files as $file) {
+      $target_pathname = str_replace("/standard/config/install", "/testing/config/optional", $file->getPathname());
+      $this->filesystem->copy($file->getPathname(), $target_pathname, TRUE);
+    }
   }
 
   /**
    * Installs Drupal.
-   *
-   * @param string $profile
-   *   The machine name of the profile to install, e.g., "lightning".
    */
-  private function installDrupal(string $profile): void {
+  private function installDrupal(): void {
     $this->output->section('Installing Drupal');
     $this->processRunner->runFixtureVendorBin([
       'drush',
       'site:install',
-      $profile,
+      $this->profile,
       "install_configure_form.update_status_module='[FALSE,FALSE]'",
       'install_configure_form.enable_update_status_module=NULL',
       '--site-name=ORCA',
@@ -91,6 +223,40 @@ class SiteInstaller {
       '--verbose',
       '--ansi',
     ]);
+  }
+
+  /**
+   * Restores the Testing profile.
+   */
+  private function restoreTestingProfile(): void {
+    if (!$this->isTestingProfile()) {
+      return;
+    }
+
+    $this->filesystem->remove($this->profilePath);
+    $this->filesystem->mirror($this->profileBackupPath, $this->profilePath);
+    $this->filesystem->remove($this->profileBackupPath);
+  }
+
+  /**
+   * Enables Acquia Drupal extensions.
+   *
+   * @throws \Exception
+   */
+  private function enableExtensions(): void {
+    $this->acquiaExtensionEnabler->enable();
+    try {
+      $this->processRunner->runFixtureVendorBin([
+        'drush',
+        'config:set',
+        'node.settings',
+        'use_admin_theme',
+        TRUE,
+      ]);
+    }
+    catch (ProcessFailedException $e) {
+      // Swallow an irrelevant exception in case node.settings doesn't exist.
+    }
   }
 
 }


### PR DESCRIPTION
This changes the site installer to use Seven as the admin theme and enable the Toolbar module for greater production-likeness and easier debugging.