### PR TITLE
Add upstream ORCA status to end of Travis CI output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
   directories:
     - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
+    - "$HOME/.rvm"
     - "${TMPDIR:-/tmp}/phpstan/cache"
 
 branches:

--- a/bin/travis/after_script.sh
+++ b/bin/travis/after_script.sh
@@ -7,10 +7,16 @@
 #     after_script.sh
 #
 # DESCRIPTION
-#     Logs the job on cron if telemetry is enabled.
+#     Conditionally logs the job and displays upstream ORCA status.
 
 cd "$(dirname "$0")" || exit; source _includes.sh
 
+# Log the job on cron if telemetry is enabled.
 if [[ "$TRAVIS_EVENT_TYPE" = "cron" && "$ORCA_TELEMETRY_ENABLE" && "$ORCA_AMPLITUDE_API_KEY" && "$ORCA_AMPLITUDE_USER_ID" ]]; then
   orca internal:log-job
 fi
+
+# Show ORCA's own current build status. A failure may signify an upstream issue
+# or service level outage that could have affected this build.
+# @see https://travis-ci.org/acquia/orca/branches
+travis history --no-interactive --repo=acquia/orca --branch=master --limit=1 --date

--- a/bin/travis/before_install.sh
+++ b/bin/travis/before_install.sh
@@ -40,6 +40,9 @@ composer global require \
   hirak/prestissimo \
   zaporylie/composer-drupal-optimizations
 
+# Install Travis command line client.
+gem install travis
+
 # Install ORCA.
 composer -d"$ORCA_ROOT" install
 

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -32,6 +32,7 @@ cache:
   directories:
     - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
+    - "$HOME/.rvm"
     - "${TMPDIR:-/tmp}/phpstan/cache"
 
 env:


### PR DESCRIPTION
This adds output of ORCA's own latest build status to the end of ORCA jobs (e.g., below) to help identify when a build failure may have been caused by an issue unrelated to the system under test.

```bash
# Show ORCA's own current build status. A failure may signify an upstream issue
# or service level outage that could have affected this build. For details:
# @see https://travis-ci.org/acquia/orca/branches
travis history --repo=acquia/orca --branch=master --limit=1 --date
2019-10-04 01:34:15 #1636 passed:    master Merge branch 'release/1.0.0'
```

Be sure to add the rvm cache directory to your `.travis.yml`

```diff
   directories:
     - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
+    - "$HOME/.rvm"
     - "${TMPDIR:-/tmp}/phpstan/cache"

 env:
```
