### PR TITLE
Add the ability to specify the coding standard used by PHPCS

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -7,6 +7,7 @@ parameters:
   env(ORCA_FIXTURE_DIR): "%app.fixture_dir%"
   env(ORCA_PACKAGES_CONFIG): config/packages.yml
   env(ORCA_PACKAGES_CONFIG_ALTER): ~
+  env(ORCA_PHPCS_STANDARD): "AcquiaDrupalTransitional"
   env(ORCA_TELEMETRY_ENABLE): false
 
 services:
@@ -17,6 +18,7 @@ services:
     bind:
       $amplitude_api_key: "%env(ORCA_AMPLITUDE_API_KEY)%"
       $amplitude_user_id: "%env(ORCA_AMPLITUDE_USER_ID)%"
+      $default_phpcs_standard: "%env(ORCA_PHPCS_STANDARD)%"
       $fixture_dir: "%env(ORCA_FIXTURE_DIR)%"
       $project_dir: "%kernel.project_dir%"
       $packages_config: "%env(ORCA_PACKAGES_CONFIG)%"

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -18,6 +18,8 @@ These affect ORCA in all contexts.
 
 * <a name="ORCA_PACKAGES_CONFIG_ALTER"></a>**`ORCA_PACKAGES_CONFIG_ALTER`**: Alter the main list of packages ORCA installs in fixtures and runs tests on (add, remove, or change packages and their properties). Acceptable values are any valid path to a YAML file relative to ORCA itself, e.g., `../example/tests/packages_alter.yml`. See [`.travis.yml`](../.travis.yml) and [`example/tests/packages_alter.yml`](../example/tests/packages_alter.yml) for an example and explanation of the schema. **Note:** This option should be used conservatively as it erodes the uniformity at the heart of ORCA's _representative_ nature.
 
+* <a name="ORCA_PHPCS_STANDARD"></a>**`ORCA_PHPCS_STANDARD`**: Change the PHP Code Sniffer standard used by the `qa:static-analysis` and `qa:fixer` commands. Acceptable values are `AcquiaPHP`, `AcquiaDrupalStrict`, and `AcquiaDrupalTransitional`. See [Acquia Coding Standards for PHP](https://packagist.org/packages/acquia/coding-standards) for details.
+
 * <a name="ORCA_TELEMETRY_ENABLE"></a>**`ORCA_TELEMETRY_ENABLE`**: Set to `TRUE` to enable telemetry with Amplitude. Requires [`ORCA_AMPLITUDE_API_KEY`](#ORCA_AMPLITUDE_API_KEY) and [`ORCA_AMPLITUDE_USER_ID`](#ORCA_AMPLITUDE_USER_ID) values. On Travis CI, only takes effect for cron events.
 
 ### Travis CI scripts

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -59,6 +59,12 @@ env:
     # @see https://github.com/acquia/orca/blob/master/docs/advanced-usage.md#ORCA_FIXTURE_PROFILE
     # - ORCA_FIXTURE_PROFILE=example
     #
+    # Change the PHP Code Sniffer standard used for static analysis. Acceptable
+    # values are "AcquiaPHP", "AcquiaDrupalStrict", and
+    # "AcquiaDrupalTransitional". Defaults to "AcquiaDrupalTransitional".
+    # @see https://github.com/acquia/orca/blob/master/docs/advanced-usage.md#ORCA_PHPCS_STANDARD
+    # - ORCA_PHPCS_STANDARD=AcquiaDrupalTransitional
+    #
     # To enable telemetry with Amplitude on cron runs, uncomment the following
     # line and set ORCA_AMPLITUDE_API_KEY in your Travis CI repository settings:
     # @see https://github.com/acquia/orca/blob/master/docs/advanced-usage.md#ORCA_TELEMETRY_ENABLE

--- a/resources/phpcs.xml
+++ b/resources/phpcs.xml
@@ -16,7 +16,8 @@
   <exclude-pattern>vendor/</exclude-pattern>
   <exclude-pattern>var/</exclude-pattern>
 
-  <rule ref="AcquiaDrupalTransitional"/>
+  <!-- This value is replaced at runtime by \Acquia\Orca\Task\PhpcsConfigurator -->
+  <rule ref="{{ STANDARD }}"/>
 
   <!-- @todo Remove after updating to the next release of Coder module.
    @see https://www.drupal.org/project/coder/issues/3066108 -->

--- a/src/Command/Qa/QaFixerCommand.php
+++ b/src/Command/Qa/QaFixerCommand.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Orca\Command\Qa;
 
+use Acquia\Orca\Enum\PhpcsStandard;
 use Acquia\Orca\Enum\StatusCode;
 use Acquia\Orca\Task\Fixer\ComposerNormalizeTask;
 use Acquia\Orca\Task\Fixer\PhpCodeBeautifierAndFixerTask;
@@ -54,10 +55,19 @@ class QaFixerCommand extends Command {
   protected static $defaultName = 'qa:fixer';
 
   /**
+   * The default PHPCS standard.
+   *
+   * @var string
+   */
+  private $defaultPhpcsStandard;
+
+  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Task\Fixer\ComposerNormalizeTask $composer_normalize
    *   The Composer normalize task.
+   * @param string $default_phpcs_standard
+   *   The default PHPCS standard.
    * @param \Symfony\Component\Filesystem\Filesystem $filesystem
    *   The filesystem.
    * @param \Acquia\Orca\Task\Fixer\PhpCodeBeautifierAndFixerTask $php_code_beautifier_and_fixer
@@ -65,8 +75,9 @@ class QaFixerCommand extends Command {
    * @param \Acquia\Orca\Task\TaskRunner $task_runner
    *   The task runner.
    */
-  public function __construct(ComposerNormalizeTask $composer_normalize, Filesystem $filesystem, PhpCodeBeautifierAndFixerTask $php_code_beautifier_and_fixer, TaskRunner $task_runner) {
+  public function __construct(ComposerNormalizeTask $composer_normalize, string $default_phpcs_standard, Filesystem $filesystem, PhpCodeBeautifierAndFixerTask $php_code_beautifier_and_fixer, TaskRunner $task_runner) {
     $this->composerNormalize = $composer_normalize;
+    $this->defaultPhpcsStandard = $default_phpcs_standard;
     $this->filesystem = $filesystem;
     $this->phpCodeBeautifierAndFixer = $php_code_beautifier_and_fixer;
     $this->taskRunner = $task_runner;
@@ -83,7 +94,11 @@ class QaFixerCommand extends Command {
       ->setHelp('Tools can be specified individually or in combination. If none are specified, all will be run.')
       ->addArgument('path', InputArgument::REQUIRED, 'The path to fix issues in')
       ->addOption('composer', NULL, InputOption::VALUE_NONE, 'Run the Composer Normalizer tool')
-      ->addOption('phpcbf', NULL, InputOption::VALUE_NONE, 'Run the PHP Code Beautifier and Fixer tool');
+      ->addOption('phpcbf', NULL, InputOption::VALUE_NONE, 'Run the PHP Code Beautifier and Fixer tool')
+      ->addOption('phpcs-standard', NULL, InputOption::VALUE_REQUIRED, implode(PHP_EOL, array_merge(
+        ['Change the PHPCS standard used:'],
+        PhpcsStandard::commandHelp()
+      )), $this->defaultPhpcsStandard);
   }
 
   /**
@@ -95,7 +110,13 @@ class QaFixerCommand extends Command {
       $output->writeln(sprintf('Error: No such path: %s.', $path));
       return StatusCode::ERROR;
     }
-    $this->configureTaskRunner($input);
+    try {
+      $this->configureTaskRunner($input);
+    }
+    catch (\UnexpectedValueException $e) {
+      $output->writeln($e->getMessage());
+      return StatusCode::ERROR;
+    }
     return $this->taskRunner
       ->setPath($path)
       ->run();
@@ -116,8 +137,33 @@ class QaFixerCommand extends Command {
       $this->taskRunner->addTask($this->composerNormalize);
     }
     if ($all || $phpcbf) {
+      $this->phpCodeBeautifierAndFixer->setStandard($this->getStandard($input));
       $this->taskRunner->addTask($this->phpCodeBeautifierAndFixer);
     }
+  }
+
+  /**
+   * Gets the PHPCS standard to use.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *   The command input.
+   *
+   * @return \Acquia\Orca\Enum\PhpcsStandard
+   *   The PHPCS standard.
+   */
+  private function getStandard(InputInterface $input): PhpcsStandard {
+    $standard = $input->getOption('phpcs-standard') ?? $this->defaultPhpcsStandard;
+    try {
+      $standard = new PhpcsStandard($standard);
+    }
+    catch (\UnexpectedValueException $e) {
+      $error_message = sprintf('Error: Invalid value for "--phpcs-standard" option: "%s".', $standard);
+      if (!$input->getParameterOption('--phpcs-standard')) {
+        $error_message = sprintf('Error: Invalid value for $ORCA_PHPCS_STANDARD environment variable: "%s".', $standard);
+      }
+      throw new \UnexpectedValueException($error_message, NULL, $e);
+    }
+    return $standard;
   }
 
 }

--- a/src/Enum/PhpcsStandard.php
+++ b/src/Enum/PhpcsStandard.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Acquia\Orca\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Provides PHPCS standards.
+ */
+final class PhpcsStandard extends Enum {
+
+  public const ACQUIA_PHP = 'AcquiaPHP';
+
+  public const ACQUIA_DRUPAL_STRICT = 'AcquiaDrupalStrict';
+
+  public const ACQUIA_DRUPAL_TRANSITIONAL = 'AcquiaDrupalTransitional';
+
+  public const DEFAULT = self::ACQUIA_DRUPAL_TRANSITIONAL;
+
+  /**
+   * Provides help text for commands that accept Drupal core version input.
+   *
+   * @return array
+   *   An array of lines.
+   */
+  public static function commandHelp() {
+    return [
+      sprintf('- %s: Contains sniffs applicable to all PHP projects', self::ACQUIA_PHP),
+      sprintf('- %s: Recommended for new Drupal projects and teams familiar with Drupal coding standards', self::ACQUIA_DRUPAL_STRICT),
+      sprintf('- %s: A relaxed standard for legacy Drupal codebases or teams new to Drupal coding standards', self::ACQUIA_DRUPAL_TRANSITIONAL),
+    ];
+  }
+
+}

--- a/src/Task/PhpcsConfigurator.php
+++ b/src/Task/PhpcsConfigurator.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Acquia\Orca\Task;
+
+use Acquia\Orca\Enum\PhpcsStandard;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Configures PHPCS.
+ */
+class PhpcsConfigurator {
+
+  private const VALUE_PLACEHOLDER = '{{ STANDARD }}';
+
+  /**
+   * The filesystem.
+   *
+   * @var \Symfony\Component\Filesystem\Filesystem
+   */
+  private $filesystem;
+
+  /**
+   * The ORCA project directory.
+   *
+   * @var string
+   */
+  private $projectDir;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+   *   The filesystem.
+   * @param string $project_dir
+   *   The ORCA project directory.
+   */
+  public function __construct(Filesystem $filesystem, string $project_dir) {
+    $this->filesystem = $filesystem;
+    $this->projectDir = $project_dir;
+  }
+
+  /**
+   * The temporary directory.
+   *
+   * @var string|null
+   */
+  private $tempDir;
+
+  /**
+   * Prepares the temporary config.
+   *
+   * @param \Acquia\Orca\Enum\PhpcsStandard $standard
+   *   The PHPCS standard to use.
+   */
+  public function prepareTemporaryConfig(PhpcsStandard $standard): void {
+    $this->filesystem->mkdir($this->getTempDir());
+    $this->filesystem->touch($this->getTemporaryConfigFile());
+    $template = file_get_contents($this->getConfigFileTemplate());
+    $contents = str_replace(self::VALUE_PLACEHOLDER, $standard->getValue(), $template);
+    $this->filesystem->dumpFile($this->getTemporaryConfigFile(), $contents);
+  }
+
+  /**
+   * Cleans up the temporary config.
+   */
+  public function cleanupTemporaryConfig(): void {
+    $this->filesystem->remove($this->getTempDir());
+  }
+
+  /**
+   * Gets the temporary directory.
+   *
+   * @return string
+   *   The temporary directory.
+   */
+  public function getTempDir(): string {
+    if ($this->tempDir) {
+      return $this->tempDir;
+    }
+
+    $path = sprintf('%s/var/cache/phpcs/%s', $this->projectDir, uniqid());
+    $this->tempDir = $path;
+    return $this->tempDir;
+  }
+
+  /**
+   * Gets the path to the config file template.
+   *
+   * @return string
+   *   The path to the config file template.
+   */
+  private function getConfigFileTemplate(): string {
+    return "{$this->projectDir}/resources/phpcs.xml";
+  }
+
+  /**
+   * Gets the path to the temporary config file.
+   *
+   * @return string
+   *   The path to the temporary config file.
+   */
+  private function getTemporaryConfigFile(): string {
+    return "{$this->getTempDir()}/phpcs.xml";
+  }
+
+}

--- a/src/Task/TaskBase.php
+++ b/src/Task/TaskBase.php
@@ -63,6 +63,13 @@ abstract class TaskBase implements TaskInterface {
   protected $output;
 
   /**
+   * The PHPCS configurator.
+   *
+   * @var \Acquia\Orca\Task\PhpcsConfigurator
+   */
+  protected $phpcsConfigurator;
+
+  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Utility\ConfigFileOverrider $config_file_overrider
@@ -73,16 +80,25 @@ abstract class TaskBase implements TaskInterface {
    *   The fixture.
    * @param \Symfony\Component\Console\Style\SymfonyStyle $output
    *   The output decorator.
+   * @param \Acquia\Orca\Task\PhpcsConfigurator $phpcs_configurator
+   *   The PHPCS configurator.
    * @param \Acquia\Orca\Utility\ProcessRunner $process_runner
    *   The process runner.
    * @param string $project_dir
    *   The ORCA project directory.
    */
-  public function __construct(ConfigFileOverrider $config_file_overrider, Filesystem $filesystem, Fixture $fixture, SymfonyStyle $output, ProcessRunner $process_runner, string $project_dir) {
+  public function __construct(ConfigFileOverrider $config_file_overrider, Filesystem $filesystem, Fixture $fixture, SymfonyStyle $output, PhpcsConfigurator $phpcs_configurator, ProcessRunner $process_runner, string $project_dir) {
     $this->configFileOverrider = $config_file_overrider;
     $this->filesystem = $filesystem;
     $this->fixture = $fixture;
     $this->output = $output;
+
+    // @todo The injection of this service in a base class like this constitutes
+    //   a violation of the interface segregation principle because not all of
+    //   its children use it. This is an indication for refactoring to use
+    //   composition instead of inheritance.
+    $this->phpcsConfigurator = $phpcs_configurator;
+
     $this->processRunner = $process_runner;
     $this->projectDir = $project_dir;
   }

--- a/tests/Command/Qa/QaFixerCommandTest.php
+++ b/tests/Command/Qa/QaFixerCommandTest.php
@@ -3,6 +3,7 @@
 namespace Acquia\Orca\Tests\Command\Qa;
 
 use Acquia\Orca\Command\Qa\QaFixerCommand;
+use Acquia\Orca\Enum\PhpcsStandard;
 use Acquia\Orca\Enum\StatusCode;
 use Acquia\Orca\Task\Fixer\ComposerNormalizeTask;
 use Acquia\Orca\Task\Fixer\PhpCodeBeautifierAndFixerTask;
@@ -21,6 +22,8 @@ class QaFixerCommandTest extends CommandTestBase {
 
   private const SUT_PATH = '/var/www/example';
 
+  private $defaultPhpcsStandard = PhpcsStandard::DEFAULT;
+
   protected function setUp() {
     $this->composerNormalize = $this->prophesize(ComposerNormalizeTask::class);
     $this->filesystem = $this->prophesize(Filesystem::class);
@@ -37,7 +40,7 @@ class QaFixerCommandTest extends CommandTestBase {
     $php_code_beautifier_and_fixer = $this->phpCodeBeautifierAndFixer->reveal();
     /** @var \Acquia\Orca\Task\TaskRunner $task_runner */
     $task_runner = $this->taskRunner->reveal();
-    return new QaFixerCommand($composer_normalize, $filesystem, $php_code_beautifier_and_fixer, $task_runner);
+    return new QaFixerCommand($composer_normalize, $this->defaultPhpcsStandard, $filesystem, $php_code_beautifier_and_fixer, $task_runner);
   }
 
   /**
@@ -111,6 +114,116 @@ class QaFixerCommandTest extends CommandTestBase {
     return [
       [['--composer' => 1], 'composerNormalize'],
       [['--phpcbf' => 1], 'phpCodeBeautifierAndFixer'],
+    ];
+  }
+
+  /**
+   * @dataProvider providerPhpcsStandardOption
+   */
+  public function testPhpcsStandardOption($args, $standard) {
+    $this->filesystem
+      ->exists(self::SUT_PATH)
+      ->shouldBeCalledOnce()
+      ->willReturn(TRUE);
+    $this->phpCodeBeautifierAndFixer
+      ->setStandard(new PhpcsStandard($standard))
+      ->shouldBeCalledOnce();
+    $this->taskRunner
+      ->addTask($this->phpCodeBeautifierAndFixer->reveal())
+      ->shouldBeCalledOnce()
+      ->willReturn($this->taskRunner);
+    $this->taskRunner
+      ->setPath(self::SUT_PATH)
+      ->shouldBeCalledOnce()
+      ->willReturn($this->taskRunner);
+    $this->taskRunner
+      ->run()
+      ->shouldBeCalledOnce();
+    $args['--phpcbf'] = 1;
+    $args['path'] = self::SUT_PATH;
+
+    $this->executeCommand($args);
+
+    $this->assertEquals('', $this->getDisplay(), 'Displayed correct output.');
+    $this->assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerPhpcsStandardOption() {
+    return [
+      [[], $this->defaultPhpcsStandard],
+      [['--phpcs-standard' => PhpcsStandard::ACQUIA_PHP], PhpcsStandard::ACQUIA_PHP],
+      [['--phpcs-standard' => PhpcsStandard::ACQUIA_DRUPAL_TRANSITIONAL], PhpcsStandard::ACQUIA_DRUPAL_TRANSITIONAL],
+      [['--phpcs-standard' => PhpcsStandard::ACQUIA_DRUPAL_STRICT], PhpcsStandard::ACQUIA_DRUPAL_STRICT],
+    ];
+  }
+
+  /**
+   * @dataProvider providerPhpcsStandardEnvVar
+   */
+  public function testPhpcsStandardEnvVar($standard) {
+    $this->defaultPhpcsStandard = $standard;
+    $this->filesystem
+      ->exists(self::SUT_PATH)
+      ->shouldBeCalledTimes(1)
+      ->willReturn(TRUE);
+    $this->phpCodeBeautifierAndFixer
+      ->setStandard(new PhpcsStandard($this->defaultPhpcsStandard))
+      ->shouldBeCalledOnce();
+    $this->taskRunner
+      ->addTask($this->phpCodeBeautifierAndFixer->reveal())
+      ->shouldBeCalledOnce()
+      ->willReturn($this->taskRunner);
+    $this->taskRunner
+      ->setPath(self::SUT_PATH)
+      ->shouldBeCalledOnce()
+      ->willReturn($this->taskRunner);
+    $this->taskRunner
+      ->run()
+      ->shouldBeCalledOnce();
+    $args = [
+      '--phpcbf' => 1,
+      'path' => self::SUT_PATH,
+    ];
+
+    $this->executeCommand($args);
+
+    $this->assertEquals('', $this->getDisplay(), 'Displayed correct output.');
+    $this->assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerPhpcsStandardEnvVar() {
+    return [
+      [PhpcsStandard::ACQUIA_PHP],
+      [PhpcsStandard::ACQUIA_DRUPAL_TRANSITIONAL],
+      [PhpcsStandard::ACQUIA_DRUPAL_STRICT],
+    ];
+  }
+
+  /**
+   * @dataProvider providerInvalidPhpcsStandard
+   */
+  public function testInvalidPhpcsStandard($args, $default_standard, $display) {
+    $this->defaultPhpcsStandard = $default_standard;
+    $this->filesystem
+      ->exists(self::SUT_PATH)
+      ->shouldBeCalledOnce()
+      ->willReturn(TRUE);
+    $this->taskRunner
+      ->run()
+      ->shouldNotBeCalled();
+    $args['--phpcbf'] = 1;
+    $args['path'] = self::SUT_PATH;
+
+    $this->executeCommand($args);
+
+    $this->assertEquals($display, $this->getDisplay(), 'Displayed correct output.');
+    $this->assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerInvalidPhpcsStandard() {
+    return [
+      [['--phpcs-standard' => 'invalid'], $this->defaultPhpcsStandard, 'Error: Invalid value for "--phpcs-standard" option: "invalid".' . PHP_EOL],
+      [[], 'invalid', 'Error: Invalid value for $ORCA_PHPCS_STANDARD environment variable: "invalid".' . PHP_EOL],
     ];
   }
 

--- a/tests/Task/TasksTest.php
+++ b/tests/Task/TasksTest.php
@@ -3,6 +3,7 @@
 namespace Acquia\Orca\Tests\Task;
 
 use Acquia\Orca\Fixture\Fixture;
+use Acquia\Orca\Task\PhpcsConfigurator;
 use Acquia\Orca\Task\StaticAnalysisTool\ComposerValidateTask;
 use Acquia\Orca\Task\StaticAnalysisTool\PhpCodeSnifferTask;
 use Acquia\Orca\Task\StaticAnalysisTool\PhpLintTask;
@@ -29,11 +30,13 @@ class TasksTest extends TestCase {
     $fixture = $this->prophesize(Fixture::class)->reveal();
     /** @var \Symfony\Component\Console\Style\SymfonyStyle $output */
     $output = $this->prophesize(SymfonyStyle::class)->reveal();
+    /** @var \Acquia\Orca\Task\PhpcsConfigurator $phpcs_configurator */
+    $phpcs_configurator = $this->prophesize(PhpcsConfigurator::class)->reveal();
     /** @var \Acquia\Orca\Utility\ProcessRunner $process_runner */
     $process_runner = $this->prophesize(ProcessRunner::class)->reveal();
     $project_dir = '/var/www/orca';
 
-    $object = new $class($config_file_overrider, $filesystem, $fixture, $output, $process_runner, $project_dir);
+    $object = new $class($config_file_overrider, $filesystem, $fixture, $output, $phpcs_configurator, $process_runner, $project_dir);
 
     $this->assertInstanceOf($class, $object, sprintf('Successfully instantiated class: %s.', $class));
   }


### PR DESCRIPTION
This adds the ability to change the PHP Code Sniffer standard used by the `qa:static-analysis` and `qa:fixer` commands via a `--phpcs-standard` command line option or `$ORCA_PHPCS_STANDARD` environment variable. See the updated `example/.travis.yml` under `env.global` for an example of setting the value for Travis CI builds.