### PR TITLE
Add Travis CI build config validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 language: php
 
+os: [ linux ]
+
+version: ~> 1.0
+
 php: "7.2"
 
 addons:
@@ -27,7 +31,7 @@ env:
     - ORCA_PACKAGES_CONFIG_ALTER=example/tests/packages_alter.yml
     - ORCA_SUT_DIR=${TRAVIS_BUILD_DIR}/../example
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - { name: "Static code analysis", env: ORCA_JOB=STATIC_CODE_ANALYSIS }

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -16,8 +16,17 @@
 #
 # For advanced needs,
 # @see https://github.com/acquia/orca/blob/develop/docs/advanced-usage.md
+#
+# For all Travis CI build config options,
+# @see https://config.travis-ci.com/
 ---
 language: php
+
+os: linux
+
+# Activate build config validation.
+# @see https://docs.travis-ci.com/user/build-config-validation
+version: ~> 1.0
 
 # The lowest version of PHP supported by all of Drupal, Acquia, and ORCA itself.
 # @see https://www.drupal.org/docs/8/system-requirements/php-requirements
@@ -74,7 +83,7 @@ env:
 
 # Execution time is drastically reduced by splitting the build into multiple
 # concurrent jobs.
-matrix:
+jobs:
   # Mark the build as finished once the only remaining jobs are allowed to fail.
   fast_finish: true
   include:


### PR DESCRIPTION
[Travis CI has added a build config validation feature!](https://changelog.travis-ci.com/build-config-validation-now-in-beta-124160) To activate it, just add the following to you `.travis.yml` file:

```yaml
version: ~> 1.0
```

[See the changes to `example/.travis.yml`](https://github.com/acquia/orca/pull/50/files#diff-d4d0734800d2e7b12348a512116c2e56) for additional, optional updates.