### PR TITLE
BLT Project dev version not installed on BLT builds.

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -340,7 +340,7 @@ class FixtureCreator {
       '--no-interaction',
       'acquia/blt-project',
     ];
-    if ($this->sut === 'acquia/blt' || $this->isDev) {
+    if ($this->sut->getPackageName() === 'acquia/blt' || $this->isDev) {
       $command[] = '--stability=dev';
     }
     else {

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -340,7 +340,7 @@ class FixtureCreator {
       '--no-interaction',
       'acquia/blt-project',
     ];
-    if ($this->sut->getPackageName() === 'acquia/blt' || $this->isDev) {
+    if (($this->sut && $this->sut->getPackageName() === 'acquia/blt') || $this->isDev) {
       $command[] = '--stability=dev';
     }
     else {


### PR DESCRIPTION
I realized in troubleshooting https://github.com/acquia/blt/pull/3942 that ORCA is installing the stable release of BLT Project from Packagist even during BLT test runs. The expected behavior is for it to be pulling the local dev version via a Composer path repository.

The problem seems to be that `$this->sut` is not a string, but an instance of `Acquia\Orca\Fixture\Package`, so the `--stability=dev` parameter never gets applied.

You can see that this patch works as intended in the downstream PR:
- [Failing test before patch](https://travis-ci.com/acquia/blt/jobs/263684756#L711), with wrong blt project version
- [Passing test after patch](https://travis-ci.com/acquia/blt/jobs/264256283#L712), with correct local blt project version