### PR TITLE
Updated Lightning component version matrix for Drupal core 8.8

### DIFF
--- a/bin/pipelines/packages_alter.yml
+++ b/bin/pipelines/packages_alter.yml
@@ -1,7 +1,7 @@
 ---
 acquia/lightning:
   type: drupal-profile
-  version: ~3.0
+  version: ~4.0
 
 # Let Lightning manage its own components.
 drupal/lightning_api: ~

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -70,7 +70,7 @@ acquia/drupal-spec-tool:
 
 drupal/lightning_api:
   core_matrix:
-    8.7.x:
+    8.7.x || 8.8.x:
       version: 4.x
       version_dev: 4.x-dev
     8.6.x:
@@ -88,6 +88,9 @@ drupal/lightning_api:
 
 drupal/lightning_core:
   core_matrix:
+    8.8.x:
+      version: 5.x
+      version_dev: 5.x-dev
     8.7.x:
       version: 4.x
       version_dev: 4.x-dev
@@ -106,7 +109,7 @@ drupal/lightning_core:
 
 drupal/lightning_layout:
   core_matrix:
-    8.7.x:
+    8.7.x || 8.8.x:
       version: 2.x
       version_dev: 2.x-dev
     8.6.x:
@@ -118,7 +121,7 @@ drupal/lightning_layout:
 
 drupal/lightning_media:
   core_matrix:
-    8.6.x || 8.7.x:
+    8.6.x || 8.7.x || 8.8.x:
       version: 3.x
       version_dev: 3.x-dev
     8.5.x:
@@ -133,7 +136,7 @@ drupal/lightning_media:
 
 drupal/lightning_workflow:
   core_matrix:
-    8.6.x || 8.7.x:
+    8.6.x || 8.7.x || 8.8.x:
       version: 3.x
       version_dev: 3.x-dev
     8.5.x:


### PR DESCRIPTION
Lightning and many of its components are sensitive to the version of Drupal core. Add new versions for Drupal core 8.8.