### PR TITLE
Added Composer Scaffold to ORCA

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -62,7 +62,8 @@ acquia/coding-standards:
   type: phpcodesniffer-standard
   url: ../coding-standards-php
   
-acquia/composer-scaffold: []
+acquia/composer-scaffold:
+  type: package
 
 drupal/cog:
   type: drupal-theme

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -61,6 +61,8 @@ acquia/blt:
 acquia/coding-standards:
   type: phpcodesniffer-standard
   url: ../coding-standards-php
+  
+acquia/composer-scaffold: []
 
 drupal/cog:
   type: drupal-theme

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -64,6 +64,7 @@ acquia/coding-standards:
   
 acquia/composer-scaffold:
   type: package
+  version: dev-master
 
 drupal/cog:
   type: drupal-theme


### PR DESCRIPTION
https://github.com/acquia/composer-scaffold is a minimal Composer meta-package that just provides Composer Scaffold settings that are specific to Acquia, especially setting the web-root to `docroot`. In order for it to be made open-source, it must integrate with ORCA.

It seems there's a bit of a catch-22 here, because ORCA can't composer require it until it's open source. So for now, I'm applying this PR as a patch in https://github.com/acquia/composer-scaffold/pull/2

cc @jfarrell 