### PR TITLE
Fix local path repo for blt-project.

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -58,6 +58,9 @@ drupal/acsf: []
 acquia/blt:
   type: composer-plugin
   core_matrix:
+    '>=9.0.0':
+      version: 12.x
+      version_dev: 12.x-dev
     '>=8.8.0':
       version: 11.x
       version_dev: 11.x-dev

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -346,6 +346,9 @@ class FixtureCreator {
     $version = ($this->isDev)
       ? $this->blt->getVersionDev($this->drupalCoreVersion)
       : $this->blt->getVersionRecommended($this->drupalCoreVersion);
+    if ($this->sut && $this->sut->getPackageName() === 'acquia/blt') {
+      $version = 'dev-master';
+    }
     $command = [
       'composer',
       'create-project',


### PR DESCRIPTION
BLT manages BLT Project as a subtree split in its repo, and any changes to BLT Project need to be tested when BLT is the SUT. This means pulling in acquia/blt-project as a Composer path repo.

The problem is that Composer is incredibly finicky about how it grabs (or doesn't grab) local versions of packages. Right now BLT copies blt-project to `/tmp/blt-project` as part of its test setup, and then ORCA tries to include it with `composer create-project acquia/blt-project:12.x` (or 11.x). This fails because the tmp copy of blt-project has no version info, so Composer assumes it to be `dev-master` and goes looking for an online copy when you ask for 12.x.

The best solution I can think of is for ORCA to ask for `dev-master` whenever BLT is the SUT. This couples BLT and ORCA a little more than I'd like, but I don't know a better solution. You can see this working here: https://github.com/acquia/blt/pull/4037

The only alternative I can think of is for ORCA to find whatever branch of BLT is checked out in Travis and pass that as the version parameter, and for BLT to configure the global path repo to point directly to the subtree split in Git rather than creating a tmp copy. But that seems difficult to set up and flaky.