### PR TITLE
Fixed missing dev packages in fixture on Drupal 9.

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -428,7 +428,7 @@ class FixtureCreator {
 
     // Install Drupal core dev requirements for Drupal 8.8 and later. (Before
     // that BLT required webflo/drupal-core-require-dev.)
-    if ((float) $this->drupalCoreVersion >= 8.8) {
+    if (version_compare($this->drupalCoreVersion, 8.8, '>=')) {
       $additions[] = 'drupal/core-dev';
     }
 

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -428,7 +428,7 @@ class FixtureCreator {
 
     // Install Drupal core dev requirements for Drupal 8.8 and later. (Before
     // that BLT required webflo/drupal-core-require-dev.)
-    if (version_compare($this->drupalCoreVersion, 8.8, '>=')) {
+    if (version_compare($this->drupalCoreVersion, '8.8', '>=')) {
       $additions[] = 'drupal/core-dev';
     }
 


### PR DESCRIPTION
I suspect that if the core version is something like `9.0.0-alpha1`, casting to float makes it `0` or at least something unexpected, and this causes dev packages to be missing.

By the way, I found some other float casts here if you want to check if there are similar bugs: https://github.com/acquia/orca/blob/develop/src/Utility/DrupalCoreVersionFinder.php