### PR TITLE
Fixed error adding core-dev in Drupal 9.

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -443,7 +443,7 @@ class FixtureCreator {
     }
 
     if ($this->shouldRequireDrupalCoreDev()) {
-      $additions[] = 'drupal/core-dev';
+      $additions[] = "drupal/core-dev:{$this->drupalCoreVersion}";
     }
 
     // Install requirements for deprecation checking.


### PR DESCRIPTION
If you don't specify a version for core-dev, Composer might choose a bad one like `8.8` when you have a Drupal 9 install: https://travis-ci.com/acquia/blt/jobs/296295652#L884

This fixes it: https://travis-ci.com/acquia/blt/jobs/296297267#L878