### PR TITLE
Fixed invalid composer.json in fixture.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6082,5 +6082,6 @@
         "ext-json": "*",
         "ext-sqlite3": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -627,6 +627,13 @@ class FixtureCreator {
       'is-bare' => $this->isBare,
       'is-dev' => $this->isDev,
     ]);
+    $command = [
+      'composer',
+      'update',
+      '--lock',
+    ];
+    $this->processRunner->runOrcaVendorBin($command, $this->fixture->getPath());
+
   }
 
   /**


### PR DESCRIPTION
When the fixture is initialized, composer.json is invalid (fails `composer validate`) because of the extra metadata that was added during creation with a corresponding update to the lock file.

This causes failures in downstream tests that rely on composer.json being valid (such as BLT's).

Edit: the change to ORCA's own composer.lock is unrelated, but also probably necessary :smile: 