### PR TITLE
Files directory initialized outside docroot.

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -1173,8 +1173,8 @@ PHP;
   private function setUpFilesDirectories(): void {
     $this->output->section('Setting up files directories');
     $directories = [
-      $this->fixture->getPath('sites/all/files'),
-      $this->fixture->getPath('sites/default/files'),
+      $this->fixture->getPath('docroot/sites/all/files'),
+      $this->fixture->getPath('docroot/sites/default/files'),
       $this->fixture->getPath('files-private'),
     ];
     $this->processRunner->runExecutable('mkdir', array_merge([


### PR DESCRIPTION
@TravisCarden you asked the other day where the "sites" directory in the fixture root came from. This is the answer :smile: 