### PR TITLE
PHP linting fails when there are no files to scan

### DIFF
--- a/src/Task/StaticAnalysisTool/PhpLintTask.php
+++ b/src/Task/StaticAnalysisTool/PhpLintTask.php
@@ -42,9 +42,9 @@ class PhpLintTask extends TaskBase {
       ], $this->getPath());
     }
     catch (ProcessFailedException $e) {
-      // Parallel lint exits with a 255 status code if it doesn't find any PHP
+      // Parallel lint exits with a 254 status code if it doesn't find any PHP
       // files to lint, which should not be considered a failure.
-      if ($e->getProcess()->getExitCode() == 255) {
+      if ($e->getProcess()->getExitCode() == 254) {
         return;
       }
       throw new TaskFailureException();


### PR DESCRIPTION
When there are no files to scan, PHP lint fails thusly:

```
Linting PHP files
-----------------
> '/home/travis/build/acquia/orca/vendor/bin/parallel-lint' '-e' 'inc,install,module,php,profile,test,theme' '--exclude' 'vendor' '--colors' '--blame' '.'
PHP 7.2.15 | 10 parallel jobs
No file found to check.
 [FAILURE] PHP Lint  
```

This is due to the php-parallel-lint exit code changing in the latest release of the library.

Note that although the proximal cause of this regression is the switch to the new package maintainer in https://github.com/acquia/orca/pull/78, this change was actually introduced several years ago in the unmaintained version and then never released: https://github.com/JakubOnderka/PHP-Parallel-Lint/commit/04b53a62274e11906d4bc71049db505337b3f957

Switching to the maintained version was definitely the right choice, it just had the side effect of catching up on several years of unreleased changes such as this.