### PR TITLE
Remove unnecessary ignore rule.

### DIFF
--- a/resources/phpstan.neon
+++ b/resources/phpstan.neon
@@ -32,9 +32,5 @@ parameters:
     # @see https://www.drupal.org/project/libraries/issues/2882709
     - %currentWorkingDirectory%/docroot/modules/contrib/libraries/src/*
 
-  ignoreErrors:
-    # @see https://github.com/acquia/orca/issues/27
-    - '#Call to deprecated method registerFile\(\) of class Doctrine\\Common\\Annotations\\AnnotationRegistry#'
-
 includes:
   - %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal-deprecations/deprecation_testing.neon


### PR DESCRIPTION
Previously, Annotations deprecated the `registerFile()` method in 1.x but did not provide any replacement in the 1.x branch, which is obviously not good, and forced us to ignore this deprecation warning: https://github.com/acquia/orca/issues/27

Now, thanks to this upstream fix (https://github.com/doctrine/annotations/pull/271), projects can safely remove calls to deprecated `registerFile()` in annotations 1.10. The new fallback mechanism in Annotations means that it should "just work" like before without an explicit call to `registerFile()`. Thus we no longer need this ignore rule. 