### PR TITLE
ORCA-72: Use Acquia Recommended Project instead of BLT Project for D9/BLT12.

### DIFF
--- a/bin/travis/install.sh
+++ b/bin/travis/install.sh
@@ -24,7 +24,7 @@ case "$ORCA_JOB" in
   "INTEGRATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
   "CORE_NEXT") orca debug:packages NEXT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=NEXT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
   "D9_READINESS") orca debug:packages D9_READINESS; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=D9_READINESS --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "CUSTOM") eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --profile=$ORCA_FIXTURE_PROFILE ${ORCA_CUSTOM_FIXTURE_INIT_ARGS:=}" ;;
+  "CUSTOM") eval "orca fixture:init -f --profile=$ORCA_FIXTURE_PROFILE ${ORCA_CUSTOM_FIXTURE_INIT_ARGS:=}" ;;
 esac
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" = "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then

--- a/bin/travis/script.sh
+++ b/bin/travis/script.sh
@@ -31,7 +31,7 @@ case "$ORCA_JOB" in
   "INTEGRATED_DEV") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME $SUT_ONLY" ;;
   "CORE_NEXT") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME $SUT_ONLY" ;;
   "D9_READINESS") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME --sut-only" ;;
-  "CUSTOM") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME ${ORCA_CUSTOM_TESTS_RUN_ARGS:=}" ;;
+  "CUSTOM") eval "orca qa:automated-tests ${ORCA_CUSTOM_TESTS_RUN_ARGS:=}" ;;
 esac
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" = "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -377,7 +377,7 @@ class FixtureCreator {
     }
     if (getenv("ORCA_SUT_NAME") === 'acquia/drupal-recommended-project') {
       // Have to use some unique branch name or Composer won't check out the path repo.
-      $version = getenv("ORCA_SUT_BRANCH");
+      $version = 'dev-' . getenv("ORCA_SUT_BRANCH");
     }
     $command = [
       'composer',

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -375,6 +375,10 @@ class FixtureCreator {
       $project_template = 'acquia/drupal-recommended-project';
       $version = ($this->isDev) ? 'dev-master' : '^1';
     }
+    if ($this->sut->getPackageName() === 'acquia/drupal-recommended-project') {
+      // Have to use some unique branch name or Composer won't check out the path repo.
+      $version = 'dev-bologna';
+    }
     $command = [
       'composer',
       'create-project',

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -252,7 +252,7 @@ class FixtureCreator {
    *   In case of errors.
    */
   public function create(): void {
-    $this->createBltProject();
+    $this->createProject();
     $this->fixtureConfigurator->ensureGitConfig();
     $this->configureBltProject();
     $this->fixDefaultDependencies();
@@ -358,17 +358,23 @@ class FixtureCreator {
   }
 
   /**
-   * Creates a BLT project.
+   * Creates a project.
    */
-  private function createBltProject(): void {
-    $this->output->section('Creating BLT project');
+  private function createProject(): void {
+    $this->output->section('Creating project');
     $stability_flag = '--stability=alpha';
-    if (($this->isDev || ($this->sut && $this->sut->getPackageName() === 'acquia/blt'))) {
+    if (($this->isDev || ($this->sut && ($this->sut->getPackageName() === 'acquia/blt' || $this->sut->getPackageName() === 'acquia/drupal-recommended-project')))) {
       $stability_flag = '--stability=dev';
     }
     $version = ($this->isDev)
       ? $this->blt->getVersionDev($this->drupalCoreVersion)
       : $this->blt->getVersionRecommended($this->drupalCoreVersion);
+    $project_template = 'acquia/blt-project';
+    // Handle D9 differently, since BLT Project no longer exists.
+    if (version_compare($this->getResolvedDrupalCoreVersion(), 9, '>=')) {
+      $project_template = 'acquia/drupal-recommended-project';
+      $version = ($this->isDev) ? 'dev-master' : '^1';
+    }
     $command = [
       'composer',
       'create-project',
@@ -376,7 +382,7 @@ class FixtureCreator {
       '--no-scripts',
       '--no-install',
       '--no-interaction',
-      "acquia/blt-project:{$version}",
+      "{$project_template}:{$version}",
       $stability_flag,
       $this->fixture->getPath(),
     ];

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -366,6 +366,7 @@ class FixtureCreator {
     if (($this->isDev || ($this->sut && ($this->sut->getPackageName() === 'acquia/blt' || $this->sut->getPackageName() === 'acquia/drupal-recommended-project')))) {
       $stability_flag = '--stability=dev';
     }
+    // Handle D8 fixtures (default).
     $version = ($this->isDev)
       ? $this->blt->getVersionDev($this->drupalCoreVersion)
       : $this->blt->getVersionRecommended($this->drupalCoreVersion);
@@ -375,6 +376,7 @@ class FixtureCreator {
       $project_template = 'acquia/drupal-recommended-project';
       $version = ($this->isDev) ? 'dev-master' : '^1';
     }
+    // Handle the very special case of ORCA running as part of acquia/drupal-recommended-project builds.
     if (getenv("ORCA_SUT_NAME") === 'acquia/drupal-recommended-project') {
       // Have to use some unique branch name or Composer won't check out the path repo.
       $version = 'dev-' . getenv("ORCA_SUT_BRANCH");

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -375,9 +375,9 @@ class FixtureCreator {
       $project_template = 'acquia/drupal-recommended-project';
       $version = ($this->isDev) ? 'dev-master' : '^1';
     }
-    if ($this->sut->getPackageName() === 'acquia/drupal-recommended-project') {
+    if (getenv("ORCA_SUT_NAME") === 'acquia/drupal-recommended-project') {
       // Have to use some unique branch name or Composer won't check out the path repo.
-      $version = 'dev-bologna';
+      $version = getenv("ORCA_SUT_BRANCH");
     }
     $command = [
       'composer',

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -376,9 +376,11 @@ class FixtureCreator {
       $project_template = 'acquia/drupal-recommended-project';
       $version = ($this->isDev) ? 'dev-master' : '^1';
     }
-    // Handle the very special case of ORCA running as part of acquia/drupal-recommended-project builds.
+    // Handle the very special case of ORCA running as part of
+    // acquia/drupal-recommended-project builds.
     if (getenv("ORCA_SUT_NAME") === 'acquia/drupal-recommended-project') {
-      // Have to use some unique branch name or Composer won't check out the path repo.
+      // Have to use some unique branch name or Composer won't check out the
+      // path repo.
       $version = 'dev-' . getenv("ORCA_SUT_BRANCH");
     }
     $command = [


### PR DESCRIPTION
Changes in this PR:
- Allow SUT-less ORCA jobs to run on Travis CI (since the project templates need to run ORCA but aren't a SUT themselves or associated with any SUT)
- Use the new project templates for D9 builds instead of the old BLT Project template.

Once we stop supporting D8/BLT11 we can remove BLT references entirely from ORCA, won't that be nice :)

Not sure exactly when that will be, since BLT 11 is scheduled to be EOL 2020Q4 while D8 is EOL 2021Q4. We'll need to reconcile that, but that's an issue for BLT...