### PR TITLE
Add the ability to specify an arbitrary Composer project template

### DIFF
--- a/bin/travis/_includes.sh
+++ b/bin/travis/_includes.sh
@@ -32,6 +32,8 @@ ORCA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export ORCA_ROOT
 export ORCA_FIXTURE_DIR=${ORCA_FIXTURE_DIR:="$ORCA_ROOT/../orca-build"}
 export ORCA_FIXTURE_PROFILE=${ORCA_FIXTURE_PROFILE:="orca"}
+DEFAULT_PROJECT_TEMPLATE=$([[ "$ORCA_JOB" == "D9_READINESS" ]] && echo "acquia/drupal-recommended-project" || echo "acquia/blt-project")
+export ORCA_FIXTURE_PROJECT_TEMPLATE=${ORCA_FIXTURE_PROJECT_TEMPLATE:="$DEFAULT_PROJECT_TEMPLATE"}
 export ORCA_SUT_DIR=${ORCA_SUT_DIR:=${TRAVIS_BUILD_DIR}}
 ORCA_SUT_HAS_NIGHTWATCH_TESTS=$(cd "$ORCA_SUT_DIR"; find . -regex ".*/Nightwatch/.*" -name \*.js)
 export ORCA_SUT_HAS_NIGHTWATCH_TESTS

--- a/bin/travis/install.sh
+++ b/bin/travis/install.sh
@@ -15,13 +15,13 @@ case "$ORCA_JOB" in
   "STATIC_CODE_ANALYSIS") unset ORCA_ENABLE_NIGHTWATCH ;;
   "DEPRECATED_CODE_SCAN") orca debug:packages; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --no-site-install"; unset ORCA_ENABLE_NIGHTWATCH ;;
   "DEPRECATED_CODE_SCAN_CONTRIB") orca debug:packages; eval "orca fixture:init -f --no-site-install"; unset ORCA_ENABLE_NIGHTWATCH ;;
-  "ISOLATED_RECOMMENDED") orca debug:packages CURRENT_RECOMMENDED; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=CURRENT_RECOMMENDED --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "INTEGRATED_RECOMMENDED") orca debug:packages CURRENT_RECOMMENDED; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_RECOMMENDED --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "CORE_PREVIOUS") orca debug:packages PREVIOUS_RELEASE; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=PREVIOUS_RELEASE --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "ISOLATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "INTEGRATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "CORE_NEXT") orca debug:packages NEXT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=NEXT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
-  "D9_READINESS") orca debug:packages D9_READINESS; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=D9_READINESS --dev --profile=$ORCA_FIXTURE_PROFILE" ;;
+  "ISOLATED_RECOMMENDED") orca debug:packages CURRENT_RECOMMENDED; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=CURRENT_RECOMMENDED --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "INTEGRATED_RECOMMENDED") orca debug:packages CURRENT_RECOMMENDED; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_RECOMMENDED --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "CORE_PREVIOUS") orca debug:packages PREVIOUS_RELEASE; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=PREVIOUS_RELEASE --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "ISOLATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "INTEGRATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "CORE_NEXT") orca debug:packages NEXT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=NEXT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
+  "D9_READINESS") orca debug:packages D9_READINESS; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=D9_READINESS --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
   "CUSTOM") eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --profile=$ORCA_FIXTURE_PROFILE ${ORCA_CUSTOM_FIXTURE_INIT_ARGS:=}" ;;
 esac
 

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -8,7 +8,7 @@
 # - "install_path": (optional) The path the package gets installed at relative
 #   to the fixture root, e.g., docroot/modules/contrib/example.
 #   Used internally for Drupal subextensions. Defaults by "type" to match the
-#   "installer-paths" patterns specified by BLT.
+#   "installer-paths" patterns specified by the root Composer project.
 # - "url": (optional) The path, absolute or relative to the root of a local
 #   clone of the package. Used for the "url" property of the Composer path
 #   repository used to symlink the system under test (SUT) into place. Defaults

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -630,10 +630,10 @@ Creates the test fixture
 
 ### Usage
 
-* `fixture:init [-f|--force] [--sut SUT] [--sut-only] [--bare] [--core CORE] [--dev] [--profile PROFILE] [--ignore-patch-failure] [--no-sqlite] [--no-site-install] [--prefer-source] [--symlink-all]`
+* `fixture:init [-f|--force] [--sut SUT] [--sut-only] [--bare] [--core CORE] [--dev] [--profile PROFILE] [--project-template PROJECT-TEMPLATE] [--ignore-patch-failure] [--no-sqlite] [--no-site-install] [--prefer-source] [--symlink-all]`
 * `init`
 
-Creates a BLT-based Drupal site build, includes the system under test using Composer, optionally includes all other company packages, and installs Drupal.
+Creates a Drupal site build, includes the system under test using Composer, optionally includes all other company packages, and installs Drupal.
 
 ### Options
 
@@ -708,6 +708,15 @@ The Drupal installation profile to use, e.g., "minimal". ("orca" is a pseudo-pro
 * Is multiple: no
 * Default: `'orca'`
 
+#### `--project-template`
+
+The Composer project template used to create the fixture
+
+* Accept value: yes
+* Is value required: yes
+* Is multiple: no
+* Default: `'acquia/blt-project'`
+
 #### `--ignore-patch-failure`
 
 Do not exit on failure to apply Composer patches. (Useful for debugging failures)
@@ -719,7 +728,7 @@ Do not exit on failure to apply Composer patches. (Useful for debugging failures
 
 #### `--no-sqlite`
 
-Use the default BLT database includes instead of SQLite
+Use the default database settings instead of SQLite
 
 * Accept value: no
 * Is value required: no

--- a/src/Command/Fixture/FixtureInitCommand.php
+++ b/src/Command/Fixture/FixtureInitCommand.php
@@ -117,7 +117,7 @@ class FixtureInitCommand extends Command {
     $this
       ->setAliases(['init'])
       ->setDescription('Creates the test fixture')
-      ->setHelp('Creates a BLT-based Drupal site build, includes the system under test using Composer, optionally includes all other company packages, and installs Drupal.')
+      ->setHelp('Creates a Drupal site build, includes the system under test using Composer, optionally includes all other company packages, and installs Drupal.')
 
       // Fundamental options.
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'If the fixture already exists, remove it first without confirmation')
@@ -135,8 +135,9 @@ class FixtureInitCommand extends Command {
       ->addOption('profile', NULL, InputOption::VALUE_REQUIRED, 'The Drupal installation profile to use, e.g., "minimal". ("orca" is a pseudo-profile based on "minimal", with the Toolbar module enabled and Seven as the admin theme)', FixtureCreator::DEFAULT_PROFILE)
 
       // Uncommon options.
+      ->addOption('project-template', NULL, InputOption::VALUE_REQUIRED, 'The Composer project template used to create the fixture', FixtureCreator::DEFAULT_PROJECT_TEMPLATE)
       ->addOption('ignore-patch-failure', NULL, InputOption::VALUE_NONE, 'Do not exit on failure to apply Composer patches. (Useful for debugging failures)')
-      ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default BLT database includes instead of SQLite')
+      ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default database settings instead of SQLite')
       ->addOption('no-site-install', NULL, InputOption::VALUE_NONE, 'Do not install Drupal. Supersedes the "--profile" option')
       ->addOption('prefer-source', NULL, InputOption::VALUE_NONE, 'Force installation of non-company packages from sources when possible, including VCS information. (Company packages are always installed from source.) Useful for core and contrib work')
       ->addOption('symlink-all', NULL, InputOption::VALUE_NONE, 'Symlink all possible company packages via local path repository. Packages absent from the expected location will be installed normally');
@@ -166,6 +167,7 @@ class FixtureInitCommand extends Command {
     $this->setDev($input->getOption('dev'));
     $this->setPreferSource($input->getOption('prefer-source'));
     $this->setProfile($input->getOption('profile'));
+    $this->setProjectTemplate($input->getOption('project-template'));
     $this->setSiteInstall($input->getOption('no-site-install'));
     $this->setSqlite($input->getOption('no-sqlite'));
     $this->setSymlinkAll($symlink_all);
@@ -380,6 +382,18 @@ class FixtureInitCommand extends Command {
   private function setProfile($profile): void {
     if ($profile !== FixtureCreator::DEFAULT_PROFILE) {
       $this->fixtureCreator->setProfile($profile);
+    }
+  }
+
+  /**
+   * Sets the Composer project template.
+   *
+   * @param string|string[]|bool|null $project_template
+   *   The Composer project template, e.g., "drupal/drupal-recommended-project".
+   */
+  private function setProjectTemplate($project_template): void {
+    if ($project_template !== FixtureCreator::DEFAULT_PROJECT_TEMPLATE) {
+      $this->fixtureCreator->setProjectTemplate($project_template);
     }
   }
 

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -676,6 +676,7 @@ class FixtureCreator {
       'is-sut-only' => $this->isSutOnly,
       'is-bare' => $this->isBare,
       'is-dev' => $this->isDev,
+      'project-template' => $this->projectTemplate,
     ]);
     $this->processRunner->runOrcaVendorBin([
       'composer',

--- a/src/Fixture/FixtureInspector.php
+++ b/src/Fixture/FixtureInspector.php
@@ -105,6 +105,7 @@ class FixtureInspector {
     $overview[] = ['System under test (SUT)', $this->getSutNamePretty()];
     $overview[] = ['Fixture type', $this->getFixtureType()];
     $overview[] = ['Package stability', $this->getPackageStabilitySetting()];
+    $overview[] = ['Project template', $this->getProjectTemplate()];
     $overview[] = [
       'Install profile',
       $this->getDrushStatusField('install-profile'),
@@ -218,6 +219,23 @@ class FixtureInspector {
     }
 
     return $this->getComposerJson()->get($key) ? 'Dev/HEAD' : 'Stable';
+  }
+
+  /**
+   * Gets the Composer project template used to create the fixture.
+   *
+   * @return string
+   *   The project template package/constraint string, e.g.,
+   *   acquia/drupal-recommended-project or acquia/blt-project:12.x.
+   */
+  private function getProjectTemplate(): string {
+    $key = 'extra.orca.project-template';
+
+    if (!$this->getComposerJson()->has($key)) {
+      return 'Unknown';
+    }
+
+    return $this->getComposerJson()->get($key);
   }
 
   /**

--- a/src/Fixture/Package.php
+++ b/src/Fixture/Package.php
@@ -55,7 +55,7 @@ class Package {
    *   - "install_path": (optional) The path the package gets installed at
    *     relative to the fixture root, e.g., docroot/modules/contrib/example.
    *     Used for Drupal subextensions. Defaults by "type" to match the
-   *     "installer-paths" patterns specified by BLT.
+   *     "installer-paths" patterns specified by the root Composer project.
    *   - "url": (optional) The path, absolute or relative to the fixture root,
    *     of a local clone of the package. Used for the "url" property of the
    *     Composer path repository used to symlink the system under test (SUT)

--- a/tests/Command/Fixture/FixtureInitCommandTest.php
+++ b/tests/Command/Fixture/FixtureInitCommandTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Command\Command;
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\FixtureCreator $fixtureCreator
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\FixtureRemover $fixtureRemover
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\PackageManager $packageManager
- * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\SutPreconditionsTester sutPreconditionsTester
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Fixture\SutPreconditionsTester $sutPreconditionsTester
  * @property \Prophecy\Prophecy\ObjectProphecy|\Composer\Semver\VersionParser $versionParser
  */
 class FixtureInitCommandTest extends CommandTestBase {
@@ -316,6 +316,28 @@ class FixtureInitCommandTest extends CommandTestBase {
       ->shouldBeCalledTimes(1);
 
     $this->executeCommand(['--prefer-source' => TRUE]);
+
+    $this->assertEquals('', $this->getDisplay(), 'Displayed correct output.');
+    $this->assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function testProjectTemplateOption() {
+    $project_template = 'test/example';
+    $this->drupalCoreVersionFinder
+      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
+      ->shouldBeCalledOnce()
+      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
+    $this->fixtureCreator
+      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
+      ->shouldBeCalledTimes(1);
+    $this->fixtureCreator
+      ->setProjectTemplate($project_template)
+      ->shouldBeCalledTimes(1);
+    $this->fixtureCreator
+      ->create()
+      ->shouldBeCalledTimes(1);
+
+    $this->executeCommand(['--project-template' => $project_template]);
 
     $this->assertEquals('', $this->getDisplay(), 'Displayed correct output.');
     $this->assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');

--- a/tests/Command/Fixture/FixtureInitCommandTest.php
+++ b/tests/Command/Fixture/FixtureInitCommandTest.php
@@ -278,19 +278,10 @@ class FixtureInitCommandTest extends CommandTestBase {
    * @dataProvider providerIgnorePatchFailureOption
    */
   public function testIgnorePatchFailureOption($options, $num_calls) {
-    $this->drupalCoreVersionFinder
-      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
-      ->shouldBeCalledOnce()
-      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
+    $this->setDefaultFixtureCreatorExpectations();
     $this->fixtureCreator
       ->setComposerExitOnPatchFailure(FALSE)
       ->shouldBeCalledTimes($num_calls);
-    $this->fixtureCreator
-      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
-      ->shouldBeCalledTimes(1);
-    $this->fixtureCreator
-      ->create()
-      ->shouldBeCalledTimes(1);
 
     $this->executeCommand($options);
 
@@ -306,14 +297,8 @@ class FixtureInitCommandTest extends CommandTestBase {
   }
 
   public function testFixtureCreationFailure() {
+    $this->setDefaultFixtureCreatorExpectations();
     $exception_message = 'Failed to create fixture.';
-    $this->drupalCoreVersionFinder
-      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
-      ->shouldBeCalledOnce()
-      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
-    $this->fixtureCreator
-      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
-      ->shouldBeCalledTimes(1);
     $this->fixtureCreator
       ->create(Argument::any())
       ->willThrow(new OrcaException($exception_message));
@@ -325,18 +310,9 @@ class FixtureInitCommandTest extends CommandTestBase {
   }
 
   public function testPreferSourceOption() {
-    $this->drupalCoreVersionFinder
-      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
-      ->shouldBeCalledOnce()
-      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
-    $this->fixtureCreator
-      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
-      ->shouldBeCalledTimes(1);
+    $this->setDefaultFixtureCreatorExpectations();
     $this->fixtureCreator
       ->setPreferSource(TRUE)
-      ->shouldBeCalledTimes(1);
-    $this->fixtureCreator
-      ->create()
       ->shouldBeCalledTimes(1);
 
     $this->executeCommand(['--prefer-source' => TRUE]);
@@ -375,19 +351,10 @@ class FixtureInitCommandTest extends CommandTestBase {
    * @dataProvider providerSymlinkAllOption
    */
   public function testSymlinkAllOption($options, $num_calls) {
-    $this->drupalCoreVersionFinder
-      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
-      ->shouldBeCalledOnce()
-      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
+    $this->setDefaultFixtureCreatorExpectations();
     $this->fixtureCreator
       ->setSymlinkAll(TRUE)
       ->shouldBeCalledTimes($num_calls);
-    $this->fixtureCreator
-      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
-      ->shouldBeCalledTimes(1);
-    $this->fixtureCreator
-      ->create()
-      ->shouldBeCalledTimes(1);
 
     $this->executeCommand($options);
 
@@ -402,24 +369,35 @@ class FixtureInitCommandTest extends CommandTestBase {
     ];
   }
 
-  /**
-   * @dataProvider providerSymlinkAllOptionInvalid
-   */
-  public function testSymlinkAllOptionInvalid($options) {
+  public function testSymlinkAllOptionInvalid() {
     $this->fixtureCreator
       ->create()
       ->shouldNotBeCalled();
 
-    $this->executeCommand($options);
+    $this->executeCommand([
+      '--bare' => TRUE,
+      '--symlink-all' => TRUE,
+    ]);
 
     $this->assertEquals("Error: Cannot symlink all in a bare fixture.\n", $this->getDisplay(), 'Displayed correct output.');
     $this->assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
   }
 
-  public function providerSymlinkAllOptionInvalid() {
-    return [
-      [['--bare' => TRUE, '--symlink-all' => TRUE]],
-    ];
+  private function setDefaultFixtureCreatorExpectations(): void {
+    $this->drupalCoreVersionFinder
+      ->get(new DrupalCoreVersion(DrupalCoreVersion::CURRENT_RECOMMENDED))
+      ->shouldBeCalledOnce()
+      ->willReturn(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED);
+
+    $this->fixtureCreator
+      ->setCoreVersion(self::CORE_VALUE_LITERAL_CURRENT_RECOMMENDED)
+      ->shouldBeCalledOnce();
+    $this->fixtureCreator
+      ->create()
+      ->shouldBeCalledOnce();
+    $this->fixtureCreator
+      ->setPreferSource(TRUE)
+      ->shouldNotBeCalled();
   }
 
 }


### PR DESCRIPTION
This PR adds the ability to specify any Composer project template for the test fixture through the use of a new `$ORCA_FIXTURE_PROJECT_TEMPLATE` environment variable which may be specified in your `.travis.yml`.

It also changes the default project template for the `D9_READINESS` job to [`acquia/drupal-recommended-project`](https://github.com/acquia/drupal-recommended-project), which will become Acquia's officially recommended starting point beginning with Drupal 9, when BLT will drop support for `acquia/blt-project`. Manual testing indicates that the change should have no material impact on out-of-the-box jobs.

With the possible exception of the default `D9_READINESS` project template change, no BC-breaking changes are introduced herein. The new feature is entirely opt-in. On the outside chance that it _does_ break your builds, just set the `ORCA_FIXTURE_PROJECT_TEMPLATE` variable to `acquia/blt-project` in your `.travis.yml` to override the change.