### PR TITLE
Make Composer use the local repository of a project template SUT

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -220,3 +220,14 @@ drupal/mysql56:
     '*':
       version: ~
       version_dev: ~
+
+# Composer project templates.
+
+acquia/blt-project:
+  type: project-template
+
+acquia/drupal-minimal-project:
+  type: project-template
+
+acquia/drupal-recommended-project:
+  type: project-template

--- a/src/Fixture/CodebaseCreator.php
+++ b/src/Fixture/CodebaseCreator.php
@@ -25,20 +25,6 @@ class CodebaseCreator {
   private $git;
 
   /**
-   * The fixture path handler.
-   *
-   * @var \Acquia\Orca\Helper\Filesystem\FixturePathHandler
-   */
-  private $fixture;
-
-  /**
-   * The fixture options.
-   *
-   * @var \Acquia\Orca\Fixture\FixtureOptions
-   */
-  private $options;
-
-  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Composer\Composer $composer
@@ -54,30 +40,38 @@ class CodebaseCreator {
   /**
    * Creates the codebase.
    *
-   * @param \Acquia\Orca\Fixture\FixtureOptions $fixture_options
+   * @param \Acquia\Orca\Fixture\FixtureOptions $options
    *   The fixture options.
-   * @param string $project_template_string
-   *   The Composer project template string to use, optionally including a
-   *   version constraint, e.g., "vendor/package" or "vendor/package:^1".
+   *
+   * @throws \Acquia\Orca\Helper\Exception\OrcaException
    */
-  public function create(FixtureOptions $fixture_options, string $project_template_string): void {
-    $this->options = $fixture_options;
-    $this->createProject($project_template_string);
+  public function create(FixtureOptions $options): void {
+    $this->createProject($options);
     $this->git->ensureFixtureRepo();
   }
 
   /**
    * Creates the Composer project.
    *
-   * @param string $project_template_string
-   *   The project tempalte string.
+   * @param \Acquia\Orca\Fixture\FixtureOptions $options
+   *   The fixture options.
+   *
+   * @throws \Acquia\Orca\Helper\Exception\OrcaException
    */
-  private function createProject(string $project_template_string): void {
-    $stability = 'alpha';
-    if ($this->options->isDev()) {
-      $stability = 'dev';
+  private function createProject(FixtureOptions $options): void {
+    if (!$options->hasSut()) {
+      $this->composer->createProject($options);
+      return;
     }
-    $this->composer->createProject($project_template_string, $stability);
+
+    /* @var \Acquia\Orca\Package\Package $sut */
+    $sut = $options->getSut();
+    if (!$sut->isProjectTemplate()) {
+      $this->composer->createProject($options);
+      return;
+    }
+
+    $this->composer->createProjectFromPackage($sut);
   }
 
 }

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -208,7 +208,7 @@ class FixtureCreator {
     $project_template = $this->options->getProjectTemplate();
     switch (TRUE) {
       case $this->isSutProjectTemplate():
-        return "{$project_template}:@dev";
+        return "{$project_template}:dev-bologna";
 
       case $project_template === 'acquia/blt-project':
         $version = ($this->options->isDev())
@@ -595,13 +595,13 @@ class FixtureCreator {
       $dependencies = [$sut];
     }
     foreach ($dependencies as $package_name => &$package) {
-      // Omit packages that cannot be composer required.
+      // Omit packages that cannot be Composer required.
       if (!$package->shouldGetComposerRequired()) {
         unset($dependencies[$package_name]);
         continue;
       }
 
-      // Always symlink the SUT.
+      // Always symlink a Composer requirable SUT.
       if ($package === $sut) {
         $package = $this->getLocalPackageString($package);
         continue;

--- a/src/Tool/TestRunner.php
+++ b/src/Tool/TestRunner.php
@@ -110,7 +110,7 @@ class TestRunner {
       $this->startServers();
     }
 
-    if ($this->sut) {
+    if ($this->sut && $this->sut->getPackageName() != 'acquia/drupal-recommended-project') {
       $this->runSutTests();
     }
     if (!$this->isSutOnly) {

--- a/src/Tool/TestRunner.php
+++ b/src/Tool/TestRunner.php
@@ -110,7 +110,7 @@ class TestRunner {
       $this->startServers();
     }
 
-    if ($this->sut && $this->sut->getPackageName() != 'acquia/drupal-recommended-project') {
+    if ($this->sut && !$this->sut->isProjectTemplate()) {
       $this->runSutTests();
     }
     if (!$this->isSutOnly) {


### PR DESCRIPTION
This makes progress on #90 by fixing a couple of minor issues with using project templates as SUTs, plus two major hacks that need to get ironed out:
- ORCA doesn't work its version magic when composer requiring the project template, so Composer never uses the path repo, hence the `dev-bologna` branch hack
- ORCA tries to run Drupal core tests, incorrectly interpreting them as the project-template's tests