### PR TITLE
Add support for Drupal Test Traits' Selenium2 driver

### DIFF
--- a/src/Task/TestFramework/PhpUnitTask.php
+++ b/src/Task/TestFramework/PhpUnitTask.php
@@ -29,18 +29,6 @@ class PhpUnitTask extends TestFrameworkBase {
   private $xpath;
 
   /**
-   * Constructs an instance.
-   *
-   * @param mixed ...$arguments
-   *   Arguments to pass to the parent constructor.
-   */
-  public function __construct(...$arguments) {
-    parent::__construct(...$arguments);
-    $this->doc = new \DOMDocument();
-    $this->xpath = new \DOMXPath($this->doc);
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function label(): string {
@@ -70,7 +58,9 @@ class PhpUnitTask extends TestFrameworkBase {
    */
   private function ensurePhpUnitConfig() {
     $path = $this->fixture->getPath('docroot/core/phpunit.xml');
+    $this->doc = new \DOMDocument($path);
     $this->doc->load($path);
+    $this->xpath = new \DOMXPath($this->doc);
 
     $this->ensureSimpleTestDirectory();
     $this->setSimpletestSettings();

--- a/src/Task/TestFramework/PhpUnitTask.php
+++ b/src/Task/TestFramework/PhpUnitTask.php
@@ -78,18 +78,7 @@ class PhpUnitTask extends TestFrameworkBase {
     $this->enableDrupalTestTraits();
     $this->disableSymfonyDeprecationsHelper();
     $this->setMinkDriverArguments();
-
-    // When dumping the XML document tree, PHP will encode all double quotes in
-    // the JSON string to &quot;, since the XML attribute value is itself
-    // enclosed in double quotes. There's no way to change this behavior, so we
-    // must do a string replacement in order to wrap the Mink driver arguments
-    // in single quotes.
-    // @see https://stackoverflow.com/questions/5473520/php-dom-and-single-quotes#5473718
-    $mink_arguments = $this->getMinkWebDriverArguments();
-    $search = sprintf('value="%s"', htmlentities($mink_arguments));
-    $replace = sprintf("value='%s'", $mink_arguments);
-    $xml = str_replace($search, $replace, $this->doc->saveXML());
-    file_put_contents($path, $xml);
+    $this->writeConfiguration($path);
   }
 
   /**
@@ -180,6 +169,28 @@ class PhpUnitTask extends TestFrameworkBase {
     // Create an <env> element containing a JSON array which will control how
     // the Mink driver interacts with Chromedriver.
     $this->setEnvironmentVariable('MINK_DRIVER_ARGS_WEBDRIVER', $this->getMinkWebDriverArguments());
+  }
+
+  /**
+   * Writes the PHPUnit configuration to disk.
+   *
+   * When dumping the XML document tree, PHP will encode all double quotes in
+   * the JSON string to &quot;, since the XML attribute value is itself
+   * enclosed in double quotes. There's no way to change this behavior, so we
+   * must do a string replacement in order to wrap the Mink driver arguments
+   * in single quotes.
+   *
+   * @param string $path
+   *   The path at which to write the configuration.
+   *
+   * @see https://stackoverflow.com/questions/5473520/php-dom-and-single-quotes#5473718
+   */
+  private function writeConfiguration(string $path): void {
+    $mink_arguments = $this->getMinkWebDriverArguments();
+    $search = sprintf('value="%s"', htmlentities($mink_arguments));
+    $replace = sprintf("value='%s'", $mink_arguments);
+    $xml = str_replace($search, $replace, $this->doc->saveXML());
+    file_put_contents($path, $xml);
   }
 
   /**


### PR DESCRIPTION
Right now, Drupal Test Traits supports two Mink drivers: a more esoteric JSON Wire one (https://gitlab.com/DMore/chrome-mink-driver) and the standard behat/mink-selenium2-driver. However, ORCA inadvertently only allows you to use the former, because it doesn't set the DTT_MINK_DRIVER_ARGS environment variable correctly, which is needed for the Selenium2 driver to work.

This PR adds support for this environment variable. I also took the liberty of doing some refactoring in order to reduce repetition which cropped up while implementing this.