### PR TITLE
Set Node.js to a version compatible with Drupal 9 + Nightwatch.js.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
 language: php
 
 os: [ linux ]
+dist: bionic
 
 version: ~> 1.0
 
 php: "7.2"
-
-node_js: "lts/*"
 
 addons:
   chrome: stable
@@ -48,10 +47,10 @@ jobs:
     - { name: "Custom job", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_FIXTURE_INIT_ARGS="--help" ORCA_CUSTOM_TESTS_RUN_ARGS="--help" }
     - { name: "Integrated live test", env: ORCA_JOB=LIVE_TEST ORCA_ENABLE_NIGHTWATCH=FALSE }
   allow_failures:
-    - { php: "7.3", env: ORCA_JOB=D9_READINESS }
     - env: ORCA_JOB=LIVE_TEST ORCA_ENABLE_NIGHTWATCH=FALSE
 
 before_install:
+  - nvm use 12.13.1
   - ../orca/bin/travis/self-test/before_install.sh
   - ../orca/bin/travis/before_install.sh
 

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -23,6 +23,7 @@
 language: php
 
 os: linux
+dist: bionic
 
 # Activate build config validation.
 # @see https://docs.travis-ci.com/user/build-config-validation
@@ -32,8 +33,6 @@ version: ~> 1.0
 # @see https://www.drupal.org/docs/8/system-requirements/php-requirements
 # @see https://docs.acquia.com/acquia-cloud/arch/tech-platform/
 php: "7.2"
-
-node_js: "lts/*"
 
 addons:
   # Chrome is used via ChromeDriver for web testing and browser automation.
@@ -130,6 +129,8 @@ jobs:
 
 # Install ORCA and prepare the environment.
 before_install:
+  # Set Node.js to a version compatible with Drupal 9 + Nightwatch.js.
+  - nvm use 12.13.1
   - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
 


### PR DESCRIPTION
Nightwatch support seems to have stopped working at some point. To fix it, make the following change to your `.travis.yml`:

```diff
@@ -2,13 +2,12 @@
 language: php

 os: [ linux ]
+dist: bionic

 version: ~> 1.0

 php: "7.2"

-node_js: "lts/*"
-
 addons:
   chrome: stable

@@ -52,6 +51,7 @@ jobs:
     - env: ORCA_JOB=LIVE_TEST ORCA_ENABLE_NIGHTWATCH=FALSE

 before_install:
+  - nvm use 12.13.1
   - ../orca/bin/travis/self-test/before_install.sh
   - ../orca/bin/travis/before_install.sh
```