### PR TITLE
Fixes #95: Add feature to get PHPUnit to save code coverage data.

### DIFF
--- a/bin/travis/before_install.sh
+++ b/bin/travis/before_install.sh
@@ -23,8 +23,10 @@ echo "$TRAVIS_NODE_VERSION"
 # Display the Yarn version.
 yarn --version
 
-# Disable Xdebug.
-phpenv config-rm xdebug.ini
+if [[ ! "$ORCA_COLLECT_COVERAGE" == "TRUE" ]]; then
+  # Disable Xdebug.
+  phpenv config-rm xdebug.ini
+fi
 
 {
   # Remove PHP memory limit.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -22,6 +22,10 @@ These affect ORCA in all contexts.
 
 * <a name="ORCA_TELEMETRY_ENABLE"></a>**`ORCA_TELEMETRY_ENABLE`**: Set to `TRUE` to enable telemetry with Amplitude. Requires [`ORCA_AMPLITUDE_API_KEY`](#ORCA_AMPLITUDE_API_KEY) and [`ORCA_AMPLITUDE_USER_ID`](#ORCA_AMPLITUDE_USER_ID) values. On Travis CI, only takes effect for cron events.
 
+* <a name="ORCA_COVERAGE_COLLECT"></a>**`ORCA_COVERAGE_COLLECT`**: Set to `TRUE` to enable code coverage collection with PHPUnit.
+
+* <a name="ORCA_COVERAGE_PATH"></a>**`ORCA_COVERAGE_PATH`**: Set to a path to store the clover coverage XML. If not supplied ORCA will attempt to use a reasonable default. Requires [`ORCA_COVERAGE_COLLECT`](#ORCA_COVERAGE_COLLECT).
+
 ### Travis CI scripts
 
 These affect ORCA only as invoked via the Travis CI scripts.

--- a/src/Task/TestFramework/PhpUnitTask.php
+++ b/src/Task/TestFramework/PhpUnitTask.php
@@ -225,6 +225,9 @@ class PhpUnitTask extends TestFrameworkBase {
         '--exclude-group=orca_ignore',
         '--testsuite=orca',
       ];
+      if ($this->shouldCollectCoverage()) {
+        $command[] = "--coverage-clover={$this->getCoveragePath()}/clover.xml";
+      }
       if ($this->isPublicTestsOnly()) {
         $command[] = '--group=orca_public';
       }
@@ -251,6 +254,31 @@ class PhpUnitTask extends TestFrameworkBase {
    */
   public function restoreConfig(): void {
     $this->configFileOverrider->restore();
+  }
+
+  /**
+   * Check if code coverage information should be collected.
+   *
+   * @return bool
+   *   TRUE if test coverage should be collected.
+   */
+  public function shouldCollectCoverage() : bool {
+    return filter_var(getenv('ORCA_COVERAGE_COLLECT'), \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE) === TRUE;
+  }
+
+  /**
+   * Gets the path for coverage files.
+   *
+   * @return string
+   *   The path for coverage files.
+   */
+  protected function getCoveragePath(): string {
+    if ($path = getenv('ORCA_COVERAGE_PATH')) {
+      return $path;
+    }
+    $subdir = explode(DIRECTORY_SEPARATOR, $this->getPath());
+    $subdir = end($subdir);
+    return "{$this->projectDir}/var/coverage/{$subdir}";
   }
 
 }


### PR DESCRIPTION
This reworks the changes from acquia/orca#feature/phpunit-coverage to bring it up to date with the latest ORCA codebase. It also makes coverage collection optional by way of environment variables.

Example usage:

```
env:
  global:
    - ORCA_COVERAGE_PATH=/tmp

jobs:
  fast_finish: true
  include:
   # ...
    - { name: "Isolated test w/ recommended package versions", env: ORCA_JOB=ISOLATED_RECOMMENDED ORCA_COVERAGE_COLLECT="TRUE" }
```