### PR TITLE
Add report:code-coverage command

### DIFF
--- a/bin/travis/script.sh
+++ b/bin/travis/script.sh
@@ -19,7 +19,11 @@ cd "$(dirname "$0")" || exit; source _includes.sh
 [[ "$ORCA_FIXTURE_PROFILE" = "orca" ]] || SUT_ONLY="--sut-only"
 
 case "$ORCA_JOB" in
-  "STATIC_CODE_ANALYSIS") eval "orca qa:static-analysis $ORCA_SUT_DIR"; unset ORCA_ENABLE_NIGHTWATCH ;;
+  "STATIC_CODE_ANALYSIS")
+    eval "orca qa:static-analysis $ORCA_SUT_DIR"
+    eval "orca report:code-coverage $ORCA_SUT_DIR"
+    unset ORCA_ENABLE_NIGHTWATCH
+    ;;
   "DEPRECATED_CODE_SCAN") eval "orca qa:deprecated-code-scan --sut=$ORCA_SUT_NAME"; unset ORCA_ENABLE_NIGHTWATCH ;;
   "DEPRECATED_CODE_SCAN_CONTRIB") eval "orca qa:deprecated-code-scan --contrib"; unset ORCA_ENABLE_NIGHTWATCH ;;
   "ISOLATED_RECOMMENDED") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME --sut-only" ;;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,6 +3,8 @@
 * [`analyze`](#qastatic-analysis)
 * [`backup`](#fixturebackup)
 * [`core`](#debugcore-versions)
+* [`cov`](#reportcode-coverage)
+* [`coverage`](#reportcode-coverage)
 * [`deprecations`](#qadeprecated-code-scan)
 * [`enexts`](#fixtureenable-extensions)
 * [`fix`](#qafixer)
@@ -43,6 +45,10 @@
 * [`qa:deprecated-code-scan`](#qadeprecated-code-scan)
 * [`qa:fixer`](#qafixer)
 * [`qa:static-analysis`](#qastatic-analysis)
+
+**report:**
+
+* [`report:code-coverage`](#reportcode-coverage)
 
 `help`
 ------
@@ -1662,6 +1668,94 @@ Run the YAML Lint tool
 * Is value required: no
 * Is multiple: no
 * Default: `false`
+
+#### `--help|-h`
+
+Display this help message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--ansi`
+
+Force ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+`report:code-coverage`
+----------------------
+
+Displays a code coverage report
+
+### Usage
+
+* `report:code-coverage <path>`
+* `coverage`
+* `cov`
+
+Displays a code coverage report
+
+### Arguments
+
+#### `path`
+
+The path to generate the report from
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
+
+### Options
 
 #### `--help|-h`
 

--- a/example/src/ExampleComplexity.php
+++ b/example/src/ExampleComplexity.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * An example class to provide some cyclomatic complexity for PHPLOC to report.
+ */
+class ExampleComplexity {
+
+  /**
+   * Creates some cyclomatic complexity.
+   *
+   * @return int
+   *   An arbitrary number.
+   */
+  public function createComplexity(): int {
+    $x = 0;
+    for ($y = 0; $y < 10; $y++) {
+      try {
+        $x += random_int(0, 10);
+      }
+      catch (Exception $e) {
+        $x++;
+      }
+    }
+    return $x;
+  }
+
+}

--- a/src/Command/Report/ReportCodeCoverageCommand.php
+++ b/src/Command/Report/ReportCodeCoverageCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Acquia\Orca\Command\Report;
+
+use Acquia\Orca\Enum\StatusCode;
+use Acquia\Orca\Exception\DirectoryNotFoundException;
+use Acquia\Orca\Exception\FileNotFoundException;
+use Acquia\Orca\Exception\ParseError;
+use Acquia\Orca\Report\CodeCoverageReportBuilder;
+use Acquia\Orca\Utility\StatusTable;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides a command.
+ */
+class ReportCodeCoverageCommand extends Command {
+
+  /**
+   * The default command name.
+   *
+   * @var string
+   */
+  protected static $defaultName = 'report:code-coverage';
+
+  /**
+   * The code coverage report builder.
+   *
+   * @var \Acquia\Orca\Report\CodeCoverageReportBuilder
+   */
+  private $reportBuilder;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Acquia\Orca\Report\CodeCoverageReportBuilder $report_builder
+   *   The code coverage report builder.
+   */
+  public function __construct(CodeCoverageReportBuilder $report_builder) {
+    parent::__construct(self::$defaultName);
+    $this->reportBuilder = $report_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure(): void {
+    $this
+      ->setAliases(['coverage', 'cov'])
+      ->setDescription('Displays a code coverage report')
+      ->addArgument('path', InputArgument::REQUIRED, 'The path to generate the report from');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(InputInterface $input, OutputInterface $output): int {
+    $path = $input->getArgument('path');
+    try {
+      $report = $this->reportBuilder->build($path);
+    }
+    catch (DirectoryNotFoundException $e) {
+      $output->writeln("Error: {$e->getMessage()}");
+      return StatusCode::ERROR;
+    }
+    catch (FileNotFoundException $e) {
+      $output->writeln([
+        'Error: No code coverage data available.',
+        'Hint: Use the "qa:static-analysis --phploc" command to generate it.',
+      ]);
+      return StatusCode::ERROR;
+    }
+    catch (ParseError $e) {
+      $output->writeln([
+        'Error: Invalid coverage data detected.',
+        'Hint: Use the "qa:static-analysis --phploc" command to regenerate it.',
+      ]);
+      return StatusCode::ERROR;
+    }
+
+    (new StatusTable($output))
+      ->setRows($report)
+      ->render();
+
+    return StatusCode::OK;
+  }
+
+}

--- a/src/Exception/DirectoryNotFoundException.php
+++ b/src/Exception/DirectoryNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Acquia\Orca\Exception;
+
+/**
+ * A directory not found exception.
+ */
+class DirectoryNotFoundException extends OrcaException {
+}

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Acquia\Orca\Exception;
+
+/**
+ * A file not found exception.
+ */
+class FileNotFoundException extends OrcaException {
+}

--- a/src/Exception/ParseError.php
+++ b/src/Exception/ParseError.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Acquia\Orca\Exception;
+
+/**
+ * A parsing error exception.
+ */
+class ParseError extends OrcaException {
+}

--- a/src/Filesystem/FinderFactory.php
+++ b/src/Filesystem/FinderFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Acquia\Orca\Filesystem;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Provides a factory for Symfony Finder objects for dependency injection.
+ */
+class FinderFactory {
+
+  /**
+   * Creates a Finder instance.
+   */
+  public function create(): Finder {
+    return Finder::create();
+  }
+
+}

--- a/src/Report/CodeCoverageReportBuilder.php
+++ b/src/Report/CodeCoverageReportBuilder.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Acquia\Orca\Report;
+
+use Acquia\Orca\Exception\DirectoryNotFoundException;
+use Acquia\Orca\Exception\FileNotFoundException as OrcaFileNotFoundException;
+use Acquia\Orca\Exception\ParseError as OrcaParseError;
+use Acquia\Orca\Filesystem\FinderFactory;
+use Acquia\Orca\Filesystem\OrcaPathHandler;
+use Acquia\Orca\Task\StaticAnalysisTool\PhplocTask;
+use Acquia\Orca\Utility\ConfigLoader;
+use Noodlehaus\Exception\FileNotFoundException as NoodlehausFileNotFoundExceptionAlias;
+use Noodlehaus\Exception\ParseException as NoodlehausParseException;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException as FinderDirectoryNotFoundException;
+
+/**
+ * Builds a code coverage report.
+ */
+class CodeCoverageReportBuilder {
+
+  /**
+   * The config loader.
+   *
+   * @var \Acquia\Orca\Utility\ConfigLoader
+   */
+  private $configLoader;
+
+  /**
+   * The finder.
+   *
+   * @var \Symfony\Component\Finder\Finder
+   */
+  private $finder;
+
+  /**
+   * The ORCA path handler.
+   *
+   * @var \Acquia\Orca\Filesystem\OrcaPathHandler
+   */
+  private $orca;
+
+  /**
+   * The path to analyze.
+   *
+   * @var string
+   */
+  private $path = '';
+
+  /**
+   * The PHPLOC data.
+   *
+   * @var \Noodlehaus\Config
+   */
+  private $phplocData;
+
+  /**
+   * The data on tests.
+   *
+   * @var int[]
+   */
+  private $testsData = [
+    'classes' => 0,
+    'assertions' => 0,
+  ];
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Acquia\Orca\Utility\ConfigLoader $config_loader
+   *   The config loader.
+   * @param \Acquia\Orca\Filesystem\FinderFactory $finder_factory
+   *   The finder factory.
+   * @param \Acquia\Orca\Filesystem\OrcaPathHandler $orca_path_handler
+   *   The ORCA path handler.
+   */
+  public function __construct(ConfigLoader $config_loader, FinderFactory $finder_factory, OrcaPathHandler $orca_path_handler) {
+    $this->configLoader = $config_loader;
+    $this->finder = $finder_factory->create();
+    $this->orca = $orca_path_handler;
+  }
+
+  /**
+   * Builds the report.
+   *
+   * @param string $path
+   *   The path to build the report from.
+   *
+   * @return array
+   *   The report data as multidimensional array suitable for
+   *   StatusTable::setRows().
+   *
+   * @see \Acquia\Orca\Utility\StatusTable::setRows()
+   *
+   * @throws \Exception
+   *   In case of errors.
+   */
+  public function build(string $path): array {
+    $this->path = $path;
+    $this->compileData();
+    return $this->buildTable();
+  }
+
+  /**
+   * Compiles the data from the various sources.
+   *
+   * @throws \Exception
+   *   In case of error.
+   */
+  private function compileData(): void {
+    $this->getPhplocData();
+    $this->getTestsData();
+  }
+
+  /**
+   * Gets the PHPLOC log data.
+   *
+   * @throws \Acquia\Orca\Exception\FileNotFoundException
+   *   In case of absent PHPLOC JSON log.
+   * @throws \Acquia\Orca\Exception\ParseError
+   *   In case of error parsing PHPLOC JSON log.
+   */
+  private function getPhplocData(): void {
+    $log_path = $this->orca
+      ->getPath(PhplocTask::JSON_LOG_PATH);
+    try {
+      $config = $this->configLoader->load($log_path);
+    }
+    catch (NoodlehausFileNotFoundExceptionAlias $e) {
+      throw new OrcaFileNotFoundException($e->getMessage());
+    }
+    catch (NoodlehausParseException $e) {
+      throw new OrcaParseError($e->getMessage());
+    }
+    $this->phplocData = $config->all();
+  }
+
+  /**
+   * Gets the data on tests.
+   *
+   * @throws \Acquia\Orca\Exception\DirectoryNotFoundException
+   *   In case of missing directory or non-directory path.
+   */
+  private function getTestsData(): void {
+    try {
+      $classes = $this->finder
+        ->in($this->path)
+        ->name('*Test.php')
+        ->notPath([
+          '@docroot/.*@',
+          '@var/.*@',
+          '@vendor/.*@',
+        ])
+        ->contains('public function test');
+    }
+    catch (FinderDirectoryNotFoundException $e) {
+      throw new DirectoryNotFoundException($e->getMessage());
+    }
+
+    $this->testsData['classes'] = iterator_count($classes);
+
+    foreach ($classes as $file) {
+      $contents = $file->getContents();
+      $this->testsData['assertions'] += substr_count($contents, '::assert');
+      $this->testsData['assertions'] += substr_count($contents, '->assert');
+    }
+  }
+
+  /**
+   * Compiles the report data into a table array.
+   *
+   * @return array
+   *   The report data array.
+   */
+  private function buildTable(): array {
+    $complexity = $this->phplocData['ccn'];
+    $assertions = $this->testsData['assertions'];
+    return [
+      ['  Test assertions', $assertions],
+      ['÷ Cyclomatic complexity', $complexity],
+      new TableSeparator(),
+      ['  Magic number', $this->computeMagicNumber()],
+    ];
+  }
+
+  /**
+   * Computes the health score.
+   *
+   * @return float
+   *   The score as a floating point number.
+   */
+  private function computeMagicNumber(): float {
+    $assertions = $this->testsData['assertions'];
+    $complexity = $this->phplocData['ccn'];
+
+    if (!$assertions || !$complexity) {
+      return 0;
+    }
+
+    return number_format($assertions / $complexity, 1);
+  }
+
+}

--- a/tests/Command/Report/ReportCodeCoverageCommandTest.php
+++ b/tests/Command/Report/ReportCodeCoverageCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Acquia\Orca\Tests\Command\Report;
+
+use Acquia\Orca\Command\Report\ReportCodeCoverageCommand;
+use Acquia\Orca\Enum\StatusCode;
+use Acquia\Orca\Exception\DirectoryNotFoundException as OrcaDirectoryNotFoundException;
+use Acquia\Orca\Exception\FileNotFoundException;
+use Acquia\Orca\Exception\ParseError;
+use Acquia\Orca\Filesystem\OrcaPathHandler;
+use Acquia\Orca\Report\CodeCoverageReportBuilder;
+use Acquia\Orca\Task\StaticAnalysisTool\PhplocTask;
+use Acquia\Orca\Tests\Command\CommandTestBase;
+use Acquia\Orca\Utility\ConfigLoader;
+use Prophecy\Argument;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @property \Acquia\Orca\Filesystem\OrcaPathHandler|\Prophecy\Prophecy\ObjectProphecy $orca
+ * @property \Acquia\Orca\Utility\ConfigLoader|\Prophecy\Prophecy\ObjectProphecy $config
+ * @property \Acquia\Orca\Report\CodeCoverageReportBuilder|\Prophecy\Prophecy\ObjectProphecy $reportBuilder
+ * @coversDefaultClass \Acquia\Orca\Command\Report\ReportCodeCoverageCommand
+ */
+class ReportCodeCoverageCommandTest extends CommandTestBase {
+
+  private const DEFAULT_PATH = 'test/example';
+
+  protected function setUp() {
+    $this->reportBuilder = $this->prophesize(CodeCoverageReportBuilder::class);
+    $this->config = $this->prophesize(ConfigLoader::class);
+    $this->orca = $this->prophesize(OrcaPathHandler::class);
+    $this->orca
+      ->exists(PhplocTask::JSON_LOG_PATH)
+      ->willReturn(TRUE);
+    $this->orca
+      ->getPath(Argument::any())
+      ->willReturnArgument();
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::configure
+   */
+  public function testBasicConfiguration(): void {
+    $command = $this->createCommand();
+
+    $definition = $command->getDefinition();
+    $arguments = $definition->getArguments();
+
+    self::assertEquals('report:code-coverage', $command->getName(), 'Set correct name.');
+    self::assertEquals(['coverage', 'cov'], $command->getAliases(), 'Set correct aliases.');
+    self::assertNotEmpty($command->getDescription(), 'Set a description.');
+    self::assertEquals(['path'], array_keys($arguments), 'Set correct arguments.');
+    $path_argument = $definition->getArgument('path');
+    self::assertTrue($path_argument->isRequired(), 'Required path argument.');
+  }
+
+  /**
+   * @covers ::execute
+   * @dataProvider providerHappyPath
+   */
+  public function testHappyPath(string $path, array $data, string $output): void {
+    $this->reportBuilder
+      ->build($path)
+      ->shouldBeCalledOnce()
+      ->willReturn($data);
+    $this->createCommand();
+
+    $this->executeCommand(['path' => $path]);
+
+    self::assertEquals($output, $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerHappyPath(): array {
+    return [
+      [
+        self::DEFAULT_PATH, [
+          ['Test', 1],
+          ['Example', 2],
+        ],
+        // This ugly, un-expressive string is necessary because Git and Drupal
+        // Drupal Code Sniffer can't agree on an acceptable multiline format.
+        "\n Test    : 1 \n Example : 2 \n\n",
+      ],
+      ['.', [
+        ['Lorem', 3],
+        ['Ipsum', 4],
+      ],
+        "\n Lorem : 3 \n Ipsum : 4 \n\n",
+      ],
+    ];
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testPathNotFound(): void {
+    $path = self::DEFAULT_PATH;
+    $message = 'The "example" directory does not exist.';
+    $this->reportBuilder
+      ->build($path)
+      ->willThrow(new OrcaDirectoryNotFoundException($message));
+    $this->createCommand();
+
+    $this->executeCommand(['path' => $path]);
+
+    self::assertEquals("Error: {$message}\n", $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testNoCoverageData(): void {
+    $this->reportBuilder
+      ->build(self::DEFAULT_PATH)
+      ->willThrow(FileNotFoundException::class);
+    $this->createCommand();
+
+    $this->executeCommand(['path' => self::DEFAULT_PATH]);
+
+    self::assertEquals("Error: No code coverage data available.
+Hint: Use the \"qa:static-analysis --phploc\" command to generate it.
+", $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  /**
+   * @covers ::execute
+   */
+  public function testInvalidCoverageData(): void {
+    $this->reportBuilder
+      ->build(self::DEFAULT_PATH)
+      ->willThrow(ParseError::class);
+    $this->createCommand();
+
+    $this->executeCommand(['path' => self::DEFAULT_PATH]);
+
+    self::assertEquals("Error: Invalid coverage data detected.
+Hint: Use the \"qa:static-analysis --phploc\" command to regenerate it.
+", $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  protected function createCommand(): Command {
+    $report_builder = $this->reportBuilder->reveal();
+    return new ReportCodeCoverageCommand($report_builder);
+  }
+
+}

--- a/tests/Filesystem/FinderFactoryTest.php
+++ b/tests/Filesystem/FinderFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Acquia\Orca\Tests\Filesystem;
+
+use Acquia\Orca\Filesystem\FinderFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @coversDefaultClass \Acquia\Orca\Filesystem\FinderFactory
+ * @covers ::create
+ */
+class FinderFactoryTest extends TestCase {
+
+  /**
+   * @covers ::create
+   */
+  public function testFactory() {
+    $factory = new FinderFactory();
+
+    $first = $factory->create();
+    $second = $factory->create();
+    $clone = clone($first);
+
+    self::assertInstanceOf(Finder::class, $first, 'Returned an instance of Finder.');
+    self::assertEquals($first, $second, 'Multiple calls create equal objects.');
+    self::assertNotSame($first, $second, 'Multiple calls do not return the same instance.');
+    self::assertNotSame($first, $clone, 'Cloning an instance results in a new instance.');
+
+    $first->name('test');
+
+    self::assertNotEquals($first, $second, 'Changes to one instance do not affect others.');
+  }
+
+}

--- a/tests/Report/CodeCoverageReportBuilderTest.php
+++ b/tests/Report/CodeCoverageReportBuilderTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Acquia\Orca\Tests\Report;
+
+use Acquia\Orca\Exception\DirectoryNotFoundException as OrcaDirectoryNotFoundException;
+use Acquia\Orca\Exception\FileNotFoundException as OrcaFileNotFoundException;
+use Acquia\Orca\Exception\ParseError;
+use Acquia\Orca\Filesystem\FinderFactory;
+use Acquia\Orca\Filesystem\OrcaPathHandler;
+use Acquia\Orca\Report\CodeCoverageReportBuilder;
+use Acquia\Orca\Task\StaticAnalysisTool\PhplocTask;
+use Acquia\Orca\Utility\ConfigLoader;
+use ArrayIterator;
+use Noodlehaus\Config;
+use Noodlehaus\Exception\FileNotFoundException as NoodlehausFileNotFoundException;
+use Noodlehaus\Exception\ParseException;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException as FinderDirectoryNotFoundException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * @property \ArrayIterator $classIterator
+ * @property \Noodlehaus\Config|\Prophecy\Prophecy\ObjectProphecy $config
+ * @property \Acquia\Orca\Utility\ConfigLoader|\Prophecy\Prophecy\ObjectProphecy $configLoader
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Finder\Finder $finder
+ * @property \Acquia\Orca\Filesystem\FinderFactory|\Prophecy\Prophecy\ObjectProphecy $finderFactory
+ * @property \Acquia\Orca\Filesystem\OrcaPathHandler|\Prophecy\Prophecy\ObjectProphecy $orca
+ * @coversDefaultClass \Acquia\Orca\Report\CodeCoverageReportBuilder
+ */
+class CodeCoverageReportBuilderTest extends TestCase {
+
+  private const DEFAULT_PATH = 'test/example';
+
+  private $phplocData = [
+    'directories' => 23,
+    'files' => 78,
+    'loc' => 9593,
+    'lloc' => 2011,
+    'llocClasses' => 1550,
+    'llocFunctions' => 2,
+    'llocGlobal' => 459,
+    'cloc' => 4065,
+    'ccn' => 374,
+    'ccnMethods' => 369,
+    'interfaces' => 3,
+    'traits' => 1,
+    'classes' => 71,
+    'abstractClasses' => 4,
+    'concreteClasses' => 67,
+    'functions' => 5,
+    'namedFunctions' => 2,
+    'anonymousFunctions' => 3,
+    'methods' => 393,
+    'publicMethods' => 204,
+    'nonPublicMethods' => 189,
+    'nonStaticMethods' => 391,
+    'staticMethods' => 2,
+    'constants' => 27,
+    'classConstants' => 27,
+    'globalConstants' => 0,
+    'testClasses' => 0,
+    'testMethods' => 0,
+    'ccnByLloc' => 0.1859771258080557,
+    'llocByNof' => 0.4,
+    'methodCalls' => 1101,
+    'staticMethodCalls' => 42,
+    'instanceMethodCalls' => 1059,
+    'attributeAccesses' => 803,
+    'staticAttributeAccesses' => 16,
+    'instanceAttributeAccesses' => 787,
+    'globalAccesses' => 2,
+    'globalVariableAccesses' => 0,
+    'superGlobalVariableAccesses' => 2,
+    'globalConstantAccesses' => 0,
+    'classCcnMin' => 1,
+    'classCcnAvg' => 5.92,
+    'classCcnMax' => 60,
+    'classLlocMin' => 0,
+    'classLlocAvg' => 20.666666666666668,
+    'classLlocMax' => 257,
+    'methodCcnMin' => 1,
+    'methodCcnAvg' => 1.9605263157894737,
+    'methodCcnMax' => 18,
+    'methodLlocMin' => 1,
+    'methodLlocAvg' => 3.3263157894736843,
+    'methodLlocMax' => 26,
+    'namespaces' => 21,
+    'ncloc' => 5528,
+  ];
+
+  protected function setUp(): void {
+    $this->configLoader = $this->prophesize(ConfigLoader::class);
+    $this->config = $this->prophesize(Config::class);
+    $this->finder = $this->prophesize(Finder::class);
+    $this->finder
+      ->in(Argument::any())
+      ->willReturn($this->finder);
+    $this->finder
+      ->name(Argument::any())
+      ->willReturn($this->finder);
+    $this->finder
+      ->notPath(Argument::any())
+      ->willReturn($this->finder);
+    $this->finder
+      ->contains(Argument::any())
+      ->willReturn($this->finder);
+    $this->finderFactory = $this->prophesize(FinderFactory::class);
+    $this->classIterator = new ArrayIterator([]);
+    $this->orca = $this->prophesize(OrcaPathHandler::class);
+    $this->orca
+      ->getPath(PhplocTask::JSON_LOG_PATH)
+      ->willReturnArgument();
+  }
+
+  /**
+   * @dataProvider providerHappyPath
+   */
+  public function testHappyPath(string $path, int $assertions, int $complexity, string $score): void {
+    $this->phplocData['ccn'] = $complexity;
+    $this->finder
+      ->in($path)
+      ->shouldBeCalledOnce()
+      ->willReturn($this->finder);
+    $this->finder
+      ->name('*Test.php')
+      ->shouldBeCalledOnce()
+      ->willReturn($this->finder);
+    $file_info = $this->prophesize(SplFileInfo::class);
+    $file_info
+      ->getContents()
+      ->willReturn('self::assertTrue(TRUE);');
+    $file_info = $file_info->reveal();
+    $files = array_fill(0, $assertions, $file_info);
+    $this->classIterator = new ArrayIterator($files);
+    $builder = $this->createBuilder();
+
+    $report = $builder->build($path);
+
+    self::assertEquals([
+      ['  Test assertions', $assertions],
+      ['÷ Cyclomatic complexity', $complexity],
+      new TableSeparator(),
+      ['  Magic number', $score],
+    ], $report, 'Returned correct report data.');
+  }
+
+  public function providerHappyPath(): array {
+    return [
+      ['test/example', 100, 100, '1.0'],
+      ['test/example', 200, 100, '2.0'],
+      ['test/example', 100, 200, '0.5'],
+      ['test/example', 100, 1, '100.0'],
+      ['test/example', 33, 375, '0.1'],
+      ['test/example', 0, 100, '0.0'],
+      ['test/example', 100, 0, '0.0'],
+      ['lorem/ipsum', 1, 1, '1.0'],
+    ];
+  }
+
+  public function testPathDoesNotExistOrIsNotDirectory(): void {
+    $message = 'Example message';
+    $this->finder
+      ->in(self::DEFAULT_PATH)
+      ->willThrow(new FinderDirectoryNotFoundException($message));
+    $this->expectException(OrcaDirectoryNotFoundException::class);
+    $this->expectExceptionMessage($message);
+
+    $builder = $this->createBuilder();
+
+    $builder->build(self::DEFAULT_PATH);
+  }
+
+  public function testNoCoverageData(): void {
+    $this->orca
+      ->getPath(PhplocTask::JSON_LOG_PATH)
+      ->shouldBeCalledOnce();
+    $this->configLoader
+      ->load(PhplocTask::JSON_LOG_PATH)
+      ->shouldBeCalledOnce()
+      ->willThrow(NoodlehausFileNotFoundException::class);
+    $this->expectException(OrcaFileNotFoundException::class);
+    $builder = $this->createBuilder();
+
+    $builder->build(self::DEFAULT_PATH);
+  }
+
+  public function testInvalidCoverageData(): void {
+    $this->orca
+      ->getPath(PhplocTask::JSON_LOG_PATH)
+      ->shouldBeCalledOnce();
+    $this->configLoader
+      ->load(PhplocTask::JSON_LOG_PATH)
+      ->shouldBeCalledOnce()
+      ->willThrow(ParseException::class);
+    $this->expectException(ParseError::class);
+    $builder = $this->createBuilder();
+
+    $builder->build(self::DEFAULT_PATH);
+  }
+
+  private function createBuilder(): CodeCoverageReportBuilder {
+    $this->config
+      ->all()
+      ->willReturn($this->phplocData);
+    $config = $this->config->reveal();
+    $this->configLoader
+      ->load(Argument::any())
+      ->willReturn($config);
+    $config_loader = $this->configLoader->reveal();
+    $this->finder
+      ->getIterator()
+      ->willReturn($this->classIterator);
+    $finder = $this->finder->reveal();
+    $this->finderFactory
+      ->create()
+      ->willReturn($finder);
+    $finder_factory = $this->finderFactory->reveal();
+    $orca_path_handler = $this->orca->reveal();
+    return new CodeCoverageReportBuilder($config_loader, $finder_factory, $orca_path_handler);
+  }
+
+}


### PR DESCRIPTION
Provide a command that outputs a report of select code coverage markers and a single-number heuristic "score" that project teams can use as a simplistic indicator of the package's test coverage.

Example output:
```

   Test assertions       : 111
 ÷ Cyclomatic complexity : 160
------------------------------
   Magic number          : 0.7

```