### PR TITLE
Create new 'debug:guess-version' command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,11 +3,10 @@
 * [`analyze`](#qastatic-analysis)
 * [`backup`](#fixturebackup)
 * [`core`](#debugcore-versions)
-* [`cov`](#reportcode-coverage)
-* [`coverage`](#reportcode-coverage)
 * [`deprecations`](#qadeprecated-code-scan)
 * [`enexts`](#fixtureenable-extensions)
 * [`fix`](#qafixer)
+* [`guess`](#debugguess-version)
 * [`help`](#help)
 * [`init`](#fixtureinit)
 * [`list`](#list)
@@ -26,6 +25,7 @@
 
 * [`debug:core-versions`](#debugcore-versions)
 * [`debug:env-vars`](#debugenv-vars)
+* [`debug:guess-version`](#debugguess-version)
 * [`debug:packages`](#debugpackages)
 
 **fixture:**
@@ -45,10 +45,6 @@
 * [`qa:deprecated-code-scan`](#qadeprecated-code-scan)
 * [`qa:fixer`](#qafixer)
 * [`qa:static-analysis`](#qastatic-analysis)
-
-**report:**
-
-* [`report:code-coverage`](#reportcode-coverage)
 
 `help`
 ------
@@ -305,6 +301,93 @@ Displays ORCA environment variables
 * `vars`
 
 Displays ORCA environment variables
+
+### Options
+
+#### `--help|-h`
+
+Display this help message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--ansi`
+
+Force ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+`debug:guess-version`
+---------------------
+
+Displays ORCA environment variables
+
+### Usage
+
+* `debug:guess-version <path>`
+* `guess`
+
+Displays ORCA environment variables
+
+### Arguments
+
+#### `path`
+
+The path to guess the version for
+
+* Is required: yes
+* Is array: no
+* Default: `NULL`
 
 ### Options
 
@@ -1586,7 +1669,7 @@ Runs static analysis tools
 
 ### Usage
 
-* `qa:static-analysis [--composer] [--phpcs] [--phpcs-standard PHPCS-STANDARD] [--phplint] [--phploc] [--phpmd] [--yamllint] [--] <path>`
+* `qa:static-analysis [--composer] [--coverage] [--phpcs] [--phpcs-standard PHPCS-STANDARD] [--phplint] [--phploc] [--phpmd] [--yamllint] [--] <path>`
 * `analyze`
 
 Tools can be specified individually or in combination. If none are specified, all will be run.
@@ -1606,6 +1689,15 @@ The path to analyze
 #### `--composer`
 
 Run the Composer validation tool
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--coverage`
+
+Run the code coverage estimator. Implies "--phploc"
 
 * Accept value: no
 * Is value required: no
@@ -1731,7 +1823,6 @@ Do not ask any interactive question
 * Is value required: no
 * Is multiple: no
 * Default: `false`
-
 `report:code-coverage`
 ----------------------
 

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -2,14 +2,29 @@
 
 namespace Acquia\Orca\Composer;
 
+use Acquia\Orca\Helper\Config\ConfigLoader;
+use Acquia\Orca\Helper\Exception\FileNotFoundException as OrcaFileNotFoundException;
+use Acquia\Orca\Helper\Exception\OrcaException;
+use Acquia\Orca\Helper\Exception\ParseError;
 use Acquia\Orca\Helper\Filesystem\FixturePathHandler;
 use Acquia\Orca\Helper\Process\ProcessRunner;
+use Composer\Package\Version\VersionGuesser;
+use Exception;
 use InvalidArgumentException;
+use Noodlehaus\Exception\FileNotFoundException as NoodlehausFileNotFoundExceptionAlias;
+use Noodlehaus\Exception\ParseException;
 
 /**
  * Provides a facade for encapsulating Composer interactions.
  */
 class Composer {
+
+  /**
+   * The config loader.
+   *
+   * @var \Acquia\Orca\Helper\Config\ConfigLoader
+   */
+  private $configLoader;
 
   /**
    * The fixture path.
@@ -26,16 +41,29 @@ class Composer {
   private $processRunner;
 
   /**
+   * The version guesser.
+   *
+   * @var \Composer\Package\Version\VersionGuesser
+   */
+  private $versionGuesser;
+
+  /**
    * Constructs an instance.
    *
+   * @param \Acquia\Orca\Helper\Config\ConfigLoader $config_loader
+   *   The config loader.
    * @param \Acquia\Orca\Helper\Filesystem\FixturePathHandler $fixture_path_handler
    *   The fixture path handler.
    * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
    *   The process runner.
+   * @param \Composer\Package\Version\VersionGuesser $version_guesser
+   *   The version guesser.
    */
-  public function __construct(FixturePathHandler $fixture_path_handler, ProcessRunner $process_runner) {
+  public function __construct(ConfigLoader $config_loader, FixturePathHandler $fixture_path_handler, ProcessRunner $process_runner, VersionGuesser $version_guesser) {
+    $this->configLoader = $config_loader;
     $this->fixture = $fixture_path_handler->getPath();
     $this->processRunner = $process_runner;
+    $this->versionGuesser = $version_guesser;
   }
 
   /**
@@ -61,6 +89,41 @@ class Composer {
       $project_template_string,
       $directory,
     ]);
+  }
+
+  /**
+   * Guesses the version of a local package.
+   *
+   * @param string $path
+   *   The path to the package to guess.
+   *
+   * @return string
+   *   The guessed version string.
+   *
+   * @throws \Acquia\Orca\Helper\Exception\FileNotFoundException
+   * @throws \Acquia\Orca\Helper\Exception\OrcaException
+   * @throws \Acquia\Orca\Helper\Exception\ParseError
+   */
+  public function guessVersion(string $path): string {
+    try {
+      $composer_json_path = "{$path}/composer.json";
+      $package_config = $this->configLoader
+        ->load($composer_json_path)
+        ->all();
+    }
+    catch (NoodlehausFileNotFoundExceptionAlias $e) {
+      throw new OrcaFileNotFoundException("No such file: {$composer_json_path}");
+    }
+    catch (ParseException $e) {
+      throw new ParseError("Cannot parse {$composer_json_path}");
+    }
+    catch (Exception $e) {
+      throw new OrcaException("Unknown error guessing version at {$path}");
+    }
+
+    $guess = $this->versionGuesser
+      ->guessVersion($package_config, $path);
+    return (empty($guess['version'])) ? '@dev' : $guess['version'];
   }
 
   /**

--- a/src/Console/Command/Debug/DebugGuessVersionCommand.php
+++ b/src/Console/Command/Debug/DebugGuessVersionCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Acquia\Orca\Console\Command\Debug;
+
+use Acquia\Orca\Composer\Composer;
+use Acquia\Orca\Console\Helper\StatusCode;
+use Acquia\Orca\Helper\Exception\OrcaException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides a command.
+ */
+class DebugGuessVersionCommand extends Command {
+
+  /**
+   * The default command name.
+   *
+   * @var string
+   */
+  protected static $defaultName = 'debug:guess-version';
+
+  /**
+   * The Composer facade.
+   *
+   * @var \Acquia\Orca\Composer\Composer
+   */
+  private $composer;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Acquia\Orca\Composer\Composer $composer
+   *   The Composer facade.
+   */
+  public function __construct(Composer $composer) {
+    parent::__construct(self::$defaultName);
+    $this->composer = $composer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure(): void {
+    $this
+      ->setAliases(['guess'])
+      ->setDescription('Displays ORCA environment variables')
+      ->addArgument('path', InputArgument::REQUIRED, 'The path to guess the version for');
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @SuppressWarnings(PHPMD.StaticAccess)
+   */
+  public function execute(InputInterface $input, OutputInterface $output): int {
+    $path = $input->getArgument('path');
+
+    try {
+      $guess = $this->composer->guessVersion($path);
+    }
+    catch (OrcaException $e) {
+      $output->writeln("Error: {$e->getMessage()}");
+      return StatusCode::ERROR;
+    }
+
+    $output->writeln($guess);
+    return StatusCode::OK;
+  }
+
+}

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -18,12 +18,10 @@ use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Json\JsonFile;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionGuesser;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\RepositoryFactory;
 use Composer\Semver\Comparator;
 use Composer\Semver\VersionParser;
-use Noodlehaus\Config;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use UnexpectedValueException;
 
@@ -186,13 +184,6 @@ class FixtureCreator {
   private $useSqlite = TRUE;
 
   /**
-   * The Composer version guesser.
-   *
-   * @var \Composer\Package\Version\VersionGuesser
-   */
-  private $versionGuesser;
-
-  /**
    * The Semver version parser.
    *
    * @var \Composer\Semver\VersionParser
@@ -229,12 +220,10 @@ class FixtureCreator {
    *   The package manager.
    * @param \Acquia\Orca\Fixture\SubextensionManager $subextension_manager
    *   The subextension manager.
-   * @param \Composer\Package\Version\VersionGuesser $version_guesser
-   *   The Composer version guesser.
    * @param \Composer\Semver\VersionParser $version_parser
    *   The Semver version parser.
    */
-  public function __construct(CodebaseCreator $codebase_creator, Composer $composer, DrupalCoreVersionFinder $core_version_finder, FixturePathHandler $fixture_path_handler, FixtureInspector $fixture_inspector, SiteInstaller $site_installer, SymfonyStyle $output, ProcessRunner $process_runner, PackageManager $package_manager, SubextensionManager $subextension_manager, VersionGuesser $version_guesser, VersionParser $version_parser) {
+  public function __construct(CodebaseCreator $codebase_creator, Composer $composer, DrupalCoreVersionFinder $core_version_finder, FixturePathHandler $fixture_path_handler, FixtureInspector $fixture_inspector, SiteInstaller $site_installer, SymfonyStyle $output, ProcessRunner $process_runner, PackageManager $package_manager, SubextensionManager $subextension_manager, VersionParser $version_parser) {
     $this->blt = $package_manager->getBlt();
     $this->codebaseCreator = $codebase_creator;
     $this->composer = $composer;
@@ -246,7 +235,6 @@ class FixtureCreator {
     $this->packageManager = $package_manager;
     $this->siteInstaller = $site_installer;
     $this->subextensionManager = $subextension_manager;
-    $this->versionGuesser = $version_guesser;
     $this->versionParser = $version_parser;
   }
 
@@ -928,10 +916,8 @@ class FixtureCreator {
    *   The versions of the given package, e.g., "@dev" or "dev-8.x-1.x".
    */
   private function getLocalPackageVersion(Package $package): string {
-    $path = $this->fixture->getPath($package->getRepositoryUrlRaw());
-    $package_config = (array) new Config("{$path}/composer.json");
-    $guess = $this->versionGuesser->guessVersion($package_config, $path);
-    return (empty($guess['version'])) ? '@dev' : $guess['version'];
+    $path = $package->getRepositoryUrlAbsolute();
+    return $this->composer->guessVersion($path);
   }
 
   /**

--- a/src/Helper/Config/ConfigLoader.php
+++ b/src/Helper/Config/ConfigLoader.php
@@ -5,7 +5,7 @@ namespace Acquia\Orca\Helper\Config;
 use Noodlehaus\Config;
 
 /**
- * Loads configuration.
+ * Loads configuration files.
  *
  * The sole purpose of this class is to make \Noodlehaus\Config an injectable
  * dependency.
@@ -15,17 +15,17 @@ class ConfigLoader {
   /**
    * Loads configuration.
    *
-   * @param string|array $values
+   * @param string|string[] $paths
    *   A filename or an array of filenames of configuration files.
    *
    * @return \Noodlehaus\Config
    *   A config object.
    *
-   * @throws \Exception
-   *   In case of loading or parsing errors.
+   * @throws \Noodlehaus\Exception\FileNotFoundException
+   * @throws \Noodlehaus\Exception\ParseException
    */
-  public function load($values): Config {
-    return new Config($values);
+  public function load($paths): Config {
+    return new Config($paths);
   }
 
 }

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -3,15 +3,27 @@
 namespace Acquia\Orca\Tests\Composer;
 
 use Acquia\Orca\Composer\Composer;
+use Acquia\Orca\Helper\Config\ConfigLoader;
+use Acquia\Orca\Helper\Exception\FileNotFoundException as OrcaFileNotFoundExceptionAlias;
+use Acquia\Orca\Helper\Exception\OrcaException;
+use Acquia\Orca\Helper\Exception\ParseError;
 use Acquia\Orca\Helper\Filesystem\FixturePathHandler;
 use Acquia\Orca\Helper\Process\ProcessRunner;
+use Composer\Package\Version\VersionGuesser;
+use Exception;
 use InvalidArgumentException;
+use Noodlehaus\Config;
+use Noodlehaus\Exception\FileNotFoundException as NoodlehausFileNotFoundExceptionAlias;
+use Noodlehaus\Exception\ParseException;
+use Noodlehaus\Parser\Json;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
+ * @property \Acquia\Orca\Helper\Config\ConfigLoader|\Prophecy\Prophecy\ObjectProphecy $configLoader
  * @property \Acquia\Orca\Helper\Filesystem\FixturePathHandler|\Prophecy\Prophecy\ObjectProphecy $fixturePathHandler
  * @property \Acquia\Orca\Helper\Process\ProcessRunner|\Prophecy\Prophecy\ObjectProphecy $processRunner
+ * @property \Composer\Package\Version\VersionGuesser|\Prophecy\Prophecy\ObjectProphecy $versionGuesser
  * @coversDefaultClass \Acquia\Orca\Composer\Composer
  */
 class ComposerTest extends TestCase {
@@ -19,6 +31,7 @@ class ComposerTest extends TestCase {
   private const FIXTURE_PATH = '/var/www';
 
   protected function setUp(): void {
+    $this->configLoader = $this->prophesize(ConfigLoader::class);
     $this->fixturePathHandler = $this->prophesize(FixturePathHandler::class);
     $this->fixturePathHandler
       ->getPath()
@@ -27,12 +40,15 @@ class ComposerTest extends TestCase {
     $this->processRunner
       ->runOrcaVendorBin(Argument::any(), self::FIXTURE_PATH)
       ->willReturn(0);
+    $this->versionGuesser = $this->prophesize(VersionGuesser::class);
   }
 
   private function createComposer(): Composer {
+    $config_loader = $this->configLoader->reveal();
     $fixture_path_handler = $this->fixturePathHandler->reveal();
     $process_runner = $this->processRunner->reveal();
-    return new Composer($fixture_path_handler, $process_runner);
+    $version_guesser = $this->versionGuesser->reveal();
+    return new Composer($config_loader, $fixture_path_handler, $process_runner, $version_guesser);
   }
 
   /**
@@ -61,6 +77,63 @@ class ComposerTest extends TestCase {
     return [
       ['test/example-project1', 'alpha', '/var/www/orca-build1'],
       ['test/example-project2', 'dev', '/var/www/orca-build2'],
+    ];
+  }
+
+  /**
+   * @dataProvider providerGuessVersion
+   * @covers ::guessVersion
+   */
+  public function testGuessVersion($path, $guess, $expected): void {
+    $data = ['test' => 'example'];
+    $json = json_encode($data);
+    $config = new Config($json, new Json(), TRUE);
+    $this->configLoader
+      ->load("{$path}/composer.json")
+      ->shouldBeCalledOnce()
+      ->willReturn($config);
+    $this->versionGuesser
+      ->guessVersion($data, $path)
+      ->shouldBeCalledOnce()
+      ->willReturn($guess);
+
+    $composer = $this->createComposer();
+    $actual = $composer->guessVersion($path);
+
+    self::assertEquals($expected, $actual, 'Returned correct version string.');
+  }
+
+  public function providerGuessVersion(): array {
+    return [
+      ['/var/www/package1', ['version' => '9999999-dev'], '9999999-dev'],
+      ['/var/www/package2', ['version' => 'dev-topic-branch'], 'dev-topic-branch'],
+      ['/var/www/package3', [], '@dev'],
+    ];
+  }
+
+  /**
+   * @dataProvider providerGuessVersionWithException
+   *
+   * @covers ::guessVersion
+   */
+  public function testGuessVersionWithException($caught, $thrown): void {
+    $path = '/path';
+    $composer_json_path = "{$path}/composer.json";
+    $this->configLoader
+      ->load($composer_json_path)
+      ->shouldBeCalledOnce()
+      ->willThrow($caught);
+    $this->expectExceptionObject($thrown);
+
+    $composer = $this->createComposer();
+    $composer->guessVersion($path);
+  }
+
+  public function providerGuessVersionWithException() {
+    return [
+      [new NoodlehausFileNotFoundExceptionAlias(''), new OrcaFileNotFoundExceptionAlias('No such file: /path/composer.json')],
+      [new ParseException(['message' => '']), new ParseError('Cannot parse /path/composer.json')],
+      [new Exception(''), new OrcaException('Unknown error guessing version at /path')],
     ];
   }
 

--- a/tests/Console/Command/Debug/DebugGuessVersionCommandTest.php
+++ b/tests/Console/Command/Debug/DebugGuessVersionCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Acquia\Orca\Tests\Console\Command\Debug;
+
+use Acquia\Orca\Composer\Composer;
+use Acquia\Orca\Console\Command\Debug\DebugGuessVersionCommand;
+use Acquia\Orca\Console\Helper\StatusCode;
+use Acquia\Orca\Helper\Exception\FileNotFoundException;
+use Acquia\Orca\Helper\Exception\OrcaException;
+use Acquia\Orca\Helper\Exception\ParseError;
+use Acquia\Orca\Tests\Console\Command\CommandTestBase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @property \Acquia\Orca\Composer\Composer|\Prophecy\Prophecy\ObjectProphecy $composer
+ * @coversDefaultClass \Acquia\Orca\Console\Command\Debug\DebugGuessVersionCommand
+ */
+class DebugGuessVersionCommandTest extends CommandTestBase {
+
+  private const SUT_PATH = '/var/www/example';
+
+  protected function setUp(): void {
+    $this->composer = $this->prophesize(Composer::class);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    $composer = $this->composer->reveal();
+    return new DebugGuessVersionCommand($composer);
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::configure
+   */
+  public function testBasicConfiguration(): void {
+    $command = $this->createCommand();
+
+    $definition = $command->getDefinition();
+    $arguments = $definition->getArguments();
+    $path_argument = $definition->getArgument('path');
+    $options = $definition->getOptions();
+
+    self::assertEquals('debug:guess-version', $command->getName(), 'Set correct name.');
+    self::assertEquals(['guess'], $command->getAliases(), 'Set correct aliases.');
+    self::assertNotEmpty($command->getDescription(), 'Set a description.');
+    self::assertEquals(['path'], array_keys($arguments), 'Set correct arguments.');
+    self::assertTrue($path_argument->isRequired(), 'Required path argument.');
+    self::assertEquals([], array_keys($options), 'Set correct options.');
+  }
+
+  /**
+   * @dataProvider providerExecution
+   */
+  public function testExecution($version): void {
+    $this->composer
+      ->guessVersion(self::SUT_PATH)
+      ->shouldBeCalledOnce()
+      ->willReturn($version);
+
+    $this->executeCommand(['path' => self::SUT_PATH]);
+
+    self::assertEquals("{$version}\n", $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::OK, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerExecution(): array {
+    return [
+      ['1.0.0'],
+      ['dev-topic-branch'],
+    ];
+  }
+
+  /**
+   * @dataProvider providerExecutionWithException
+   */
+  public function testExecutionWithException($exception): void {
+    $this->composer
+      ->guessVersion(Argument::any())
+      ->shouldBeCalledOnce()
+      ->willThrow($exception);
+
+    $this->executeCommand(['path' => self::SUT_PATH]);
+
+    self::assertEquals("Error: {$exception->getMessage()}\n", $this->getDisplay(), 'Displayed correct output.');
+    self::assertEquals(StatusCode::ERROR, $this->getStatusCode(), 'Returned correct status code.');
+  }
+
+  public function providerExecutionWithException(): array {
+    return [
+      [new FileNotFoundException('Lorem ipsum')],
+      [new ParseError('Dolor sit')],
+      [new OrcaException('Amet')],
+    ];
+  }
+
+}

--- a/tests/Fixture/FixtureCreatorTest.php
+++ b/tests/Fixture/FixtureCreatorTest.php
@@ -14,7 +14,6 @@ use Acquia\Orca\Helper\Filesystem\OrcaPathHandler;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Package\Package;
 use Acquia\Orca\Package\PackageManager;
-use Composer\Package\Version\VersionGuesser;
 use Composer\Semver\VersionParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -30,7 +29,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @property \Acquia\Orca\Package\PackageManager|\Prophecy\Prophecy\ObjectProphecy $packageManager
  * @property \Acquia\Orca\Drupal\DrupalCoreVersionFinder|\Prophecy\Prophecy\ObjectProphecy $coreVersionFinder
  * @property \Acquia\Orca\Helper\Process\ProcessRunner|\Prophecy\Prophecy\ObjectProphecy $processRunner
- * @property \Composer\Package\Version\VersionGuesser|\Prophecy\Prophecy\ObjectProphecy $versionGuesser
  * @property \Composer\Semver\VersionParser|\Prophecy\Prophecy\ObjectProphecy $versionParser
  * @property \Symfony\Component\Console\Style\SymfonyStyle|\Prophecy\Prophecy\ObjectProphecy $output
  */
@@ -51,7 +49,6 @@ class FixtureCreatorTest extends TestCase {
     $this->siteInstaller = $this->prophesize(SiteInstaller::class);
     $this->subextensionManager = $this->prophesize(SubextensionManager::class);
     $this->output = $this->prophesize(SymfonyStyle::class);
-    $this->versionGuesser = $this->prophesize(VersionGuesser::class);
     $this->versionParser = $this->prophesize(VersionParser::class);
   }
 
@@ -66,21 +63,9 @@ class FixtureCreatorTest extends TestCase {
     $site_installer = $this->siteInstaller->reveal();
     $subextension_manager = $this->subextensionManager->reveal();
     $output = $this->output->reveal();
-    $version_guesser = $this->versionGuesser->reveal();
     $version_parser = $this->versionParser->reveal();
     return new FixtureCreator(
-      $codebase_creator,
-      $composer_facade,
-      $core_version_finder,
-      $fixture,
-      $fixture_inspector,
-      $site_installer,
-      $output,
-      $process_runner,
-      $package_manager,
-      $subextension_manager,
-      $version_guesser,
-      $version_parser
+      $codebase_creator, $composer_facade, $core_version_finder, $fixture, $fixture_inspector, $site_installer, $output, $process_runner, $package_manager, $subextension_manager, $version_parser
     );
   }
 


### PR DESCRIPTION
This new command determines what Composer identifies as the version string for a given path repository, e.g.:

```
$ git checkout develop
Switched to branch 'develop'

$ orca debug:guess-version .
9999999-dev

$ git checkout feature/example
Switched to branch 'feature/example'

$ orca debug:guess-version .
dev-feature/example
```