### PR TITLE
Debugging info for failed SUT placement

### DIFF
--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -728,6 +728,7 @@ class FixtureCreator {
     $sut_install_path = $this->sut->getInstallPathAbsolute();
 
     if (!file_exists($sut_install_path)) {
+      $this->displayFailedPlaceDebuggingInfo();
       throw new OrcaException('Failed to place SUT at correct path.');
     }
 
@@ -735,6 +736,16 @@ class FixtureCreator {
       $this->displayFailedSymlinkDebuggingInfo();
       throw new OrcaException('Failed to symlink SUT via local path repository.');
     }
+  }
+
+  /**
+   * Displays debugging info about a failure to place the SUT.
+   */
+  private function displayFailedPlaceDebuggingInfo(): void {
+    $this->output->section('Debugging info');
+    $this->output->comment('Package type is ' . $this->sut->getType());
+    $this->output->comment('Expected install location based on this package type is ' . $this->sut->getInstallPathRelative());
+    $this->output->comment('You can modify the package type via a packages alter: https://github.com/acquia/orca/blob/develop/docs/advanced-usage.md#command-line-application');
   }
 
   /**


### PR DESCRIPTION
I got a little confused trying to integrate ORCA with Drupal Environment Detector (https://github.com/acquia/drupal-environment-detector/pull/9) because ORCA assumed it was a Drupal module and threw an exception "Failed to place SUT at correct path", which by itself isn't very helpful in diagnosing the issue.

It turned out to be pretty simple, I just need to change the SUT package type, but the exception could do a better job of leading people to that info.

See an example of the output of this patch: https://travis-ci.com/github/acquia/drupal-environment-detector/jobs/377032879#L2373