### PR TITLE
Make default project template selection automatic based on core version

### DIFF
--- a/src/Console/Command/Fixture/FixtureInitCommand.php
+++ b/src/Console/Command/Fixture/FixtureInitCommand.php
@@ -114,7 +114,7 @@ class FixtureInitCommand extends Command {
       ->addOption('profile', NULL, InputOption::VALUE_REQUIRED, 'The Drupal installation profile to use, e.g., "minimal". ("orca" is a pseudo-profile based on "minimal", with the Toolbar module enabled and Seven as the admin theme)', FixtureCreator::DEFAULT_PROFILE)
 
       // Uncommon options.
-      ->addOption('project-template', NULL, InputOption::VALUE_REQUIRED, 'The Composer project template used to create the fixture', FixtureCreator::DEFAULT_PROJECT_TEMPLATE)
+      ->addOption('project-template', NULL, InputOption::VALUE_REQUIRED, 'The Composer project template used to create the fixture')
       ->addOption('ignore-patch-failure', NULL, InputOption::VALUE_NONE, 'Do not exit on failure to apply Composer patches. (Useful for debugging failures)')
       ->addOption('no-sqlite', NULL, InputOption::VALUE_NONE, 'Use the default database settings instead of SQLite')
       ->addOption('no-site-install', NULL, InputOption::VALUE_NONE, 'Do not install Drupal. Supersedes the "--profile" option')

--- a/src/Drupal/DrupalCoreVersionFinder.php
+++ b/src/Drupal/DrupalCoreVersionFinder.php
@@ -82,8 +82,8 @@ class DrupalCoreVersionFinder {
   /**
    * Finds the Drupal core version matching the given criteria.
    *
-   * @param string|null $target_package_version
-   *   The target package version.
+   * @param string|null $target_core_version
+   *   The target core version.
    * @param string $minimum_stability
    *   The minimum stability. Available options (in order of stability) are
    *   dev, alpha, beta, RC, and stable.
@@ -94,11 +94,11 @@ class DrupalCoreVersionFinder {
    * @return string
    *   The version string.
    */
-  public function find(string $target_package_version = NULL, string $minimum_stability = 'stable', string $preferred_stability = 'stable'): string {
+  public function find(string $target_core_version = NULL, string $minimum_stability = 'stable', string $preferred_stability = 'stable'): string {
     $best_candidate = $this->getVersionSelector($minimum_stability)
-      ->findBestCandidate('drupal/core', $target_package_version, NULL, $preferred_stability);
+      ->findBestCandidate('drupal/core', $target_core_version, NULL, $preferred_stability);
     if (!$best_candidate) {
-      throw new RuntimeException(sprintf('No Drupal core version satisfies the given constraints: version=%s, minimum stability=%s', $target_package_version, $minimum_stability));
+      throw new RuntimeException(sprintf('No Drupal core version satisfies the given constraints: version=%s, minimum stability=%s', $target_core_version, $minimum_stability));
     }
     return $best_candidate->getPrettyVersion();
   }

--- a/src/Fixture/FixtureCreator.php
+++ b/src/Fixture/FixtureCreator.php
@@ -22,7 +22,6 @@ use Composer\Repository\RepositoryFactory;
 use Composer\Semver\Comparator;
 use Composer\Semver\VersionParser;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use UnexpectedValueException;
 
 /**
  * Creates a fixture.
@@ -30,8 +29,6 @@ use UnexpectedValueException;
 class FixtureCreator {
 
   public const DEFAULT_PROFILE = 'orca';
-
-  public const DEFAULT_PROJECT_TEMPLATE = 'acquia/blt-project';
 
   /**
    * The BLT package, if defined.
@@ -363,7 +360,7 @@ class FixtureCreator {
    *   Returns TRUE if it should be required, or FALSE if not.
    */
   private function shouldRequireDrupalConsole(): bool {
-    $version = $this->getResolvedDrupalCoreVersion();
+    $version = $this->options->getCoreResolved();
     return Comparator::lessThan($version, '9');
   }
 
@@ -377,29 +374,8 @@ class FixtureCreator {
    *   Returns TRUE if it should be required, or FALSE if not.
    */
   private function shouldRequireDrupalCoreDev(): bool {
-    $version = $this->getResolvedDrupalCoreVersion();
+    $version = $this->options->getCoreResolved();
     return Comparator::greaterThanOrEqualTo($version, '8.8');
-  }
-
-  /**
-   * Gets the concrete version of Drupal core that will be installed.
-   *
-   * @return string
-   *   The best match for the requested version of Drupal core, accounting for
-   *   ranges.
-   */
-  private function getResolvedDrupalCoreVersion(): string {
-    $core = $this->options->getCore();
-    try {
-      // Get the version if it's concrete as opposed to a range.
-      $version = $this->versionParser->normalize($core);
-    }
-    catch (UnexpectedValueException $e) {
-      // The requested Drupal core version is a range. Get the best match.
-      $stability = $this->options->isDev() ? 'dev' : 'stable';
-      $version = $this->coreVersionFinder->find($core, $stability, $stability);
-    }
-    return $version;
   }
 
   /**


### PR DESCRIPTION
With this change it is no longer necessary to pass a `--project-template` option to the `fixture:init` command to correspond to the `--core` value.