### PR TITLE
Add preflight test for a "version" value in the SUT's composer.json

### DIFF
--- a/src/Domain/Fixture/SutPreconditionsTester.php
+++ b/src/Domain/Fixture/SutPreconditionsTester.php
@@ -88,6 +88,7 @@ class SutPreconditionsTester {
     try {
       $this->loadComposerJson();
       $this->validateComposerJsonName();
+      $this->assertComposerJsonSpecifiesNoVersion();
     }
     catch (OrcaException $e) {
       throw $e;
@@ -128,6 +129,20 @@ class SutPreconditionsTester {
         var_export($actual_name, TRUE),
         var_export($expected_name, TRUE
       )));
+    }
+  }
+
+  /**
+   * Asserts the the SUT's composer.json does not specify a "version".
+   *
+   * @throws \Acquia\Orca\Exception\OrcaException
+   */
+  private function assertComposerJsonSpecifiesNoVersion(): void {
+    if ($this->composerJsonConfig->get('version')) {
+      throw new OrcaException(implode(PHP_EOL, [
+        "SUT composer.json must not specified a 'version'",
+        'See https://getcomposer.org/doc/04-schema.md#version',
+      ]));
     }
   }
 

--- a/tests/Domain/Fixture/SutPreconditionsTesterTest.php
+++ b/tests/Domain/Fixture/SutPreconditionsTesterTest.php
@@ -149,4 +149,20 @@ class SutPreconditionsTesterTest extends TestCase {
     $tester->test(self::SUT_NAME);
   }
 
+  public function testTestComposerVersionSpecified(): void {
+    $data = self::COMPOSER_JSON_DATA;
+    $data['version'] = 'v1.0.0';
+    $this->configLoader
+      ->load(Argument::any())
+      ->willReturn($this->createConfig($data));
+    $this->expectExceptionObject(new OrcaException(implode(PHP_EOL, [
+      "SUT composer.json must not specified a 'version'",
+      'See https://getcomposer.org/doc/04-schema.md#version',
+    ])));
+
+    $tester = $this->createSutPreconditionsTester();
+
+    $tester->test(self::SUT_NAME);
+  }
+
 }


### PR DESCRIPTION
This adds a test to the `fixture fixture:init` command's preflight SUT preconditions tests for a hardcoded `version` value in its `composer.json`, which can prevent ORCA from symlinking it in place.