### PR TITLE
Fix project template tests

### DIFF
--- a/src/Domain/Composer/ComposerFacade.php
+++ b/src/Domain/Composer/ComposerFacade.php
@@ -245,10 +245,6 @@ class ComposerFacade {
    *   TRUE to pass the --no-update or FALSE not to.
    */
   public function requirePackages(array $packages, ?bool $prefer_source = FALSE, ?bool $no_update = FALSE): void {
-    if (empty($packages)) {
-      throw new InvalidArgumentException('No packages provided to require.');
-    }
-
     $command = ['require'];
     if ($prefer_source) {
       $command[] = '--prefer-source';

--- a/tests/Domain/Composer/ComposerFacadeTest.php
+++ b/tests/Domain/Composer/ComposerFacadeTest.php
@@ -511,8 +511,17 @@ class ComposerFacadeTest extends TestCase {
     ];
   }
 
+  /**
+   * @see https://github.com/acquia/orca/pull/113
+   */
   public function testRequirePackagesEmptyArray(): void {
-    $this->expectException(InvalidArgumentException::class);
+    $this->processRunner
+      ->runOrcaVendorBin(array_merge([
+        'composer',
+        'require',
+        '--no-interaction',
+      ], []), self::FIXTURE_PATH)
+      ->shouldBeCalledOnce();
     $composer = $this->createComposer();
 
     $composer->requirePackages([]);


### PR DESCRIPTION
Commit https://github.com/acquia/orca/commit/264901b5fa849abf8a2c251fe76bac30fc1d3e91 created a regression for project templates during fixture creation: https://github.com/acquia/drupal-recommended-project/pull/14

The error is:
```
In ComposerFacade.php line 249:
                                    
  No packages provided to require.  
```

I don't quite understand the internals, but I think that commit caused fixtures to be created directly via the Composer facade rather than generically via the ORCA bin and the Composer Facade does not allow an empty package list.

I don't see why the Composer Facade should disallow an empty package list, Composer is perfectly happy to install existing packages if you don't request any new ones. Hence the change in this PR.

I also haven't been able to sort out why the unit tests (which seem to test project templates as SUTs) missed this... possibly because they are not directly invoking the Composer facade.