### PR TITLE
Remove CUSTOM ORCA_JOB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ jobs:
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     - { name: "D9 readiness test", php: "7.3", env: ORCA_JOB=D9_READINESS }
-    - { name: "Custom job", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_FIXTURE_INIT_ARGS="--help" ORCA_CUSTOM_TESTS_RUN_ARGS="--help" }
     - { name: "Integrated live test", env: ORCA_JOB=LIVE_TEST ORCA_ENABLE_NIGHTWATCH=FALSE }
   allow_failures:
     - env: ORCA_JOB=LIVE_TEST ORCA_ENABLE_NIGHTWATCH=FALSE

--- a/bin/travis/install.sh
+++ b/bin/travis/install.sh
@@ -22,7 +22,6 @@ case "$ORCA_JOB" in
   "INTEGRATED_DEV") orca debug:packages CURRENT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=CURRENT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
   "CORE_NEXT") orca debug:packages NEXT_DEV; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --core=NEXT_DEV --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
   "D9_READINESS") orca debug:packages D9_READINESS; eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --sut-only --core=D9_READINESS --dev --profile=$ORCA_FIXTURE_PROFILE --project-template=$ORCA_FIXTURE_PROJECT_TEMPLATE" ;;
-  "CUSTOM") eval "orca fixture:init -f --sut=$ORCA_SUT_NAME --profile=$ORCA_FIXTURE_PROFILE ${ORCA_CUSTOM_FIXTURE_INIT_ARGS:=}" ;;
 esac
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" = "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then

--- a/bin/travis/script.sh
+++ b/bin/travis/script.sh
@@ -29,7 +29,6 @@ case "$ORCA_JOB" in
   "INTEGRATED_DEV") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME $SUT_ONLY" ;;
   "CORE_NEXT") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME $SUT_ONLY" ;;
   "D9_READINESS") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME --sut-only" ;;
-  "CUSTOM") eval "orca qa:automated-tests --sut=$ORCA_SUT_NAME ${ORCA_CUSTOM_TESTS_RUN_ARGS:=}" ;;
 esac
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" = "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -32,25 +32,22 @@ These affect ORCA only as invoked via the Travis CI scripts.
 
 * <a name="ORCA_COVERALLS_ENABLE"></a>**`ORCA_COVERALLS_ENABLE`**: Set to `TRUE` to send test coverage data to [Coveralls](https://coveralls.io/) on the isolated/recommended job. Requires that you [add your repository to Coveralls](https://github.com/acquia/orca/blob/master/docs/faq.md#how-do-i-add-my-github-repository-to-coveralls). It is recommended to [enable notifications](https://docs.coveralls.io/coveralls-notifications). Test coverage generation greatly increases build times, so only enable it on one job--all that makes sense anyway. Note: [`ORCA_COVERAGE_ENABLE`](#ORCA_COVERAGE_ENABLE) is implied by this setting and need not be enabled if this is.
 
-* <a name="ORCA_CUSTOM_FIXTURE_INIT_ARGS"></a>**`ORCA_CUSTOM_FIXTURE_INIT_ARGS`**: Add command-line arguments to `fixture:init` invocation in the [`install`](../bin/travis/install.sh) build phase of a custom job. Example:
-
-    ```yaml
-    matrix:
-      include:
-        - { name: "Custom job", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_FIXTURE_INIT_ARGS="--profile=lightning" }
-    ```
-
-* <a name="ORCA_CUSTOM_TESTS_RUN_ARGS"></a>**`ORCA_CUSTOM_TESTS_RUN_ARGS`**: Add command-line arguments to the `qa:automated-tests` invocation in the [`script`](../bin/travis/script.sh) build phase of a custom job. Example:
-
-    ```yaml
-    matrix:
-      include:
-        - { name: "Custom job", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_TESTS_RUN_ARGS="--sut-only" }
-    ```
-
 * <a name="ORCA_FIXTURE_PROFILE"></a>**`ORCA_FIXTURE_PROFILE`**: Change the Drupal installation profile ORCA installs in fixtures. Note: Changing this value will cause non-SUT automated tests to be skipped in all jobs to avoid failures from changing such a fundamental assumption.
 
 * <a name="ORCA_FIXTURE_PROJECT_TEMPLATE"></a>**`ORCA_FIXTURE_PROJECT_TEMPLATE`**: Change the Composer project template used to create the fixture.
+
+## Adding and customizing jobs
+
+For special testing needs, custom jobs can be added and existing ones modified through the addition of scripts to your `.travis.yml`, e.g.:
+
+   ```yaml
+   before_script:
+     - ../orca/bin/travis/before_script.sh
+     # Your custom script:
+     - ./bin/travis/before_script.sh
+   ```
+
+See [the example script](https://github.com/acquia/orca/blob/master/example/bin/travis/example.sh) for more details.
 
 ---
 

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -127,10 +127,6 @@ jobs:
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     - { name: "D9 readiness test", php: "7.3", env: ORCA_JOB=D9_READINESS}
-    # Custom testing needs involving only minor variations on the standard setup
-    # can be achieved without custom scripting using the "CUSTOM" ORCA_JOB.
-    # @see https://github.com/acquia/orca/blob/master/docs/advanced-usage.md#travis-ci-scripts
-    # - { name: "Custom job", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_FIXTURE_INIT_ARGS="--profile=standard" ORCA_CUSTOM_TESTS_RUN_ARGS="--sut-only" }
   # For various reasons, some jobs are allowed to fail without failing the whole
   # build. They should still be watched for advance notice of future problems.
   # @see https://docs.travis-ci.com/user/customizing-the-build#rows-that-are-allowed-to-fail
@@ -148,6 +144,9 @@ before_install:
   - composer self-update 1.10.16
   - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
+  # For custom testing needs, add your own scripts here. See the example script
+  # for more details.
+  # - ./bin/travis/example.sh
 
 # Create the test fixture and place the SUT.
 install: ../orca/bin/travis/install.sh

--- a/example/bin/travis/example.sh
+++ b/example/bin/travis/example.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# NAME
+#     example.sh - Provide an example custom Travis CI script.
+#
+# SYNOPSIS
+#     example.sh
+#
+# DESCRIPTION
+#     Provides an example of customizing a Travis CI ORCA build by adding or
+#     modifying jobs. See live working examples:
+#     - https://github.com/acquia/coding-standards-php/tree/v0.5.0/bin/travis
+#     - https://github.com/acquia/drupal-spec-tool/tree/4.0.1/bin/travis
+#     - https://github.com/acquia/orca/tree/v2.11.3/bin/travis/self-test
+#
+#     Remember to make your script executable! E.g.:
+#     chmod u+x bin/travis/example.sh
+
+# Make bash resolve paths from the location of this script, not the CWD (current
+# working directory) of the user or process that called it.
+cd "$(dirname "$0")" || exit 1
+
+# Reuse ORCA's own includes for its $PATH additions and environment variables.
+source ../../../orca/bin/travis/_includes.sh
+
+# Travis CI provides numerous general purpose environment variables you can use.
+# @see https://docs.travis-ci.com/user/environment-variables
+echo "The SUT is cloned at $TRAVIS_BUILD_DIR"
+
+# ORCA provides additional special purpose environment variables. Use the below
+# command to see the list with current values. Its output is included in the
+# before_install phase of all Travis CI jobs for debugging purposes.
+orca debug:env-vars
+
+# Unconditioned statements will be executed on every job.
+echo "The current job is $ORCA_JOB."
+
+# Target an out-of-the-box ORCA job to modify its behavior.
+if [[ "$ORCA_JOB" == "ISOLATED_RECOMMENDED" ]]; then
+  # For example, add test dependencies before running automated tests.
+  if [[ -d "$ORCA_FIXTURE_DIR" ]]; then
+    (
+      cd "$ORCA_FIXTURE_DIR" || exit
+      composer require drupal/example
+    )
+  fi
+fi
+
+# Target any condition of your own making, e.g., an environment variable set in
+# your .travis.yml.
+if [[ "$MY_CONDITION" == "TRUE" ]]; then
+  echo "\$MY_CONDITION attained"
+fi


### PR DESCRIPTION
The "CUSTOM" `$ORCA_JOB` is being removed due to its inflexibility combined with how little it's used. Better alternatives [are documented](https://github.com/acquia/orca/blob/2f125a8dfff0214fcd3d18352664454e28940301/docs/advanced-usage.md#adding-and-customizing-jobs). Convert any usages of the old feature before updating.