### PR TITLE
Add support for PHPUnit 9 in Drupal 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - { env: ORCA_JOB=LOOSE_DEPRECATED_CODE_SCAN, name: "Loose deprecated code scan" }
     - { env: ORCA_JOB=STRICT_DEPRECATED_CODE_SCAN, name: "Strict deprecated code scan" }
     - { env: ORCA_JOB=DEPRECATED_CODE_SCAN_W_CONTRIB, name: "Deprecated code scan w/ contrib" }
-    - { env: ORCA_JOB=ISOLATED_TEST_ON_NEXT_MINOR, name: "Isolated test on next minor Drupal core version" }
+    - { env: ORCA_JOB=ISOLATED_TEST_ON_NEXT_MINOR ORCA_ENABLE_NIGHTWATCH=TRUE, name: "Isolated test on next minor Drupal core version with Nightwatch.js" }
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_NEXT_MINOR, name: "Integrated test on next minor Drupal core version" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_NEXT_MINOR_DEV, name: "Isolated test on next minor dev Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_NEXT_MINOR_DEV, name: "Integrated test on next minor dev Drupal core version" }

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -259,6 +259,10 @@ class FixtureCreator {
       $additions[] = "drupal/core-dev:{$this->options->getCore()}";
     }
 
+    if ($this->shouldRequireProphecyPhpunit()) {
+      $additions[] = 'phpspec/prophecy-phpunit:^2';
+    }
+
     // Install requirements for deprecation checking.
     $additions[] = 'mglaman/phpstan-drupal-deprecations';
     $additions[] = 'nette/di:^3.0';
@@ -295,6 +299,19 @@ class FixtureCreator {
   private function shouldRequireDrupalCoreDev(): bool {
     $version = $this->options->getCoreResolved();
     return Comparator::greaterThanOrEqualTo($version, '8.8');
+  }
+
+  /**
+   * Determines whether or not to require phpspec/prophecy-phpunit.
+   *
+   * @see https://www.drupal.org/node/3176567
+   *
+   * @return bool
+   *   Returns TRUE if it should be required, or FALSE if not.
+   */
+  private function shouldRequireProphecyPhpunit(): bool {
+    $version = $this->options->getCoreResolved();
+    return Comparator::greaterThanOrEqualTo($version, '9.1');
   }
 
   /**


### PR DESCRIPTION
Drupal core updated to PHPUnit 9 in version 9.1 ([change record](https://www.drupal.org/node/3176567)), causing some ORCA CI jobs to fail. This fixes them by requiring [`phpspec/prophecy-phpunit`](https://packagist.org/packages/phpspec/prophecy-phpunit).