### PR TITLE
Fix NEXT_MINOR_DEV jobs fail when there's no NEXT_MINOR Drupal core version yet

### DIFF
--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -55,6 +55,13 @@ class DrupalCoreVersionResolver {
   private $nextMinor;
 
   /**
+   * The next minor dev version of Drupal core.
+   *
+   * @var string|null
+   */
+  private $nextMinorDev;
+
+  /**
    * The oldest supported version of Drupal core.
    *
    * @var string|null
@@ -300,7 +307,14 @@ class DrupalCoreVersionResolver {
    * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
    */
   private function findNextMinorDev(): string {
-    return $this->convertToDev($this->findNextMinor());
+    if ($this->nextMinorDev) {
+      return $this->nextMinorDev;
+    }
+
+    $this->nextMinorDev = $this
+      ->resolveArbitrary(">{$this->findCurrent()}", 'dev', TRUE);
+
+    return $this->nextMinorDev;
   }
 
   /**


### PR DESCRIPTION
Once there is a new minor dev version of Drupal core but before there is an alpha, the `ISOLATED_TEST_ON_NEXT_MINOR_DEV` and `INTEGRATED_TEST_ON_NEXT_MINOR_DEV` ORCA jobs fail with the following error message.

```
[ERROR] No Drupal core version satisfies the given constraints: version=>9.1.0, stability=alpha
```