### PR TITLE
Add workaround for "Call to undefined method ::getAnnotations()" error

### DIFF
--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -264,6 +264,10 @@ class FixtureCreator {
       $additions[] = 'phpspec/prophecy-phpunit:^2';
     }
 
+    if ($this->shouldDowngradePhpunit()) {
+      $additions[] = 'phpunit/phpunit:9.4.3';
+    }
+
     // Require additional packages.
     $prefer_source = $this->options->preferSource();
     $no_update = !$this->options->isBare();
@@ -314,6 +318,21 @@ class FixtureCreator {
     $actual = $parser->parseConstraints($core);
 
     return $required->matches($actual);
+  }
+
+  /**
+   * Determines whether or not to downgrade PHPUnit.
+   *
+   * Workaround for "Call to undefined method ::getAnnotations()" error."
+   *
+   * @see https://www.drupal.org/project/drupal/issues/3186443
+   *
+   * @return bool
+   *   Returns TRUE if it should be downgraded, or FALSE if not.
+   */
+  private function shouldDowngradePhpunit(): bool {
+    $version = $this->options->getCoreResolved();
+    return Comparator::equalTo($version, '9.1.0.0');
   }
 
   /**


### PR DESCRIPTION
All "current Drupal core version" jobs (and consequently all builds) are currently failing with an error like the below. The cause is a Drupal core issue: [PHPUnit 9.5 Call to undefined method ::getAnnotations() [#3186443]](https://www.drupal.org/project/drupal/issues/3186443). It will be fixed in the next core release. This pull request applies a temporary workaround [described in that issue](https://www.drupal.org/project/drupal/issues/3186443#comment-13934004): downgrading PHPUnit to an earlier version for Drupal core 9.1.0 only.

```
> '/home/travis/build/acquia/orca-build/vendor/bin/phpunit' '--verbose' '--coverage-clover=/home/travis/build/logs/clover.xml' '--colors=always' '--debug' '--configuration=/home/travis/build/acquia/orca-build/docroot/core/phpunit.xml' '--exclude-group=orca_ignore' '--testsuite=orca'
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.3.14
Configuration: /home/travis/build/acquia/orca-build/docroot/core/phpunit.xml
Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
Testing 
Test 'Drupal\Tests\example\Unit\ExampleUnitTest::testPrivatePseudoGroup' started
Call to undefined method Drupal\Tests\example\Unit\ExampleUnitTest::getAnnotations()
THE ERROR HANDLER HAS CHANGED!
 [FAILURE] drupal/example: PHPUnit
```