### PR TITLE
Fix test runner trying to generate code coverage regardless of environment variable

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -14,6 +14,8 @@ These affect ORCA in all contexts.
 
 * <a name="ORCA_COVERAGE_CLOVER"></a>**`ORCA_COVERAGE_CLOVER`**: Change the path where ORCA saves the PHPUnit test coverage Clover XML file.
 
+* <a name="ORCA_COVERAGE_ENABLE"></a>**`ORCA_COVERAGE_ENABLE`**: Set to `TRUE` to generate test coverage data without automatically sending it to [Coveralls](https://coveralls.io/). The resulting Clover file will be saved at the location set in [`ORCA_COVERAGE_CLOVER`](#ORCA_COVERAGE_CLOVER). Test coverage generation greatly increases build times, so only enable it on one job--all that makes sense anyway. Note: This setting is implied by [`ORCA_COVERALLS_ENABLE`](#ORCA_COVERALLS_ENABLE) and need not be enabled if that is.
+
 * <a name="ORCA_FIXTURE_DIR"></a>**`ORCA_FIXTURE_DIR`**: Change the directory ORCA uses for test fixtures. Acceptable values are any valid, local directory reference, e.g., `/var/www/example`, or `../example`.
 
 * <a name="ORCA_PACKAGES_CONFIG"></a>**`ORCA_PACKAGES_CONFIG`**: Completely replace the list of packages ORCA installs in fixtures and runs tests on. Acceptable values are any valid path to a YAML file relative to ORCA itself, e.g., `../example/tests/packages.yml`. See [`config/packages.yml`](../config/packages.yml) for an example and explanation of the schema.
@@ -27,8 +29,6 @@ These affect ORCA in all contexts.
 ### Travis CI scripts
 
 These affect ORCA only as invoked via the Travis CI scripts.
-
-* <a name="ORCA_COVERAGE_ENABLE"></a>**`ORCA_COVERAGE_ENABLE`**: Set to `TRUE` to generate test coverage data without automatically sending it to [Coveralls](https://coveralls.io/). The resulting Clover file will be saved at the location set in [`ORCA_COVERAGE_CLOVER`](#ORCA_COVERAGE_CLOVER). Test coverage generation greatly increases build times, so only enable it on one job--all that makes sense anyway. Note: This setting is implied by [`ORCA_COVERALLS_ENABLE`](#ORCA_COVERALLS_ENABLE) and need not be enabled if that is.
 
 * <a name="ORCA_COVERALLS_ENABLE"></a>**`ORCA_COVERALLS_ENABLE`**: Set to `TRUE` to send test coverage data to [Coveralls](https://coveralls.io/) on the isolated/recommended job. Requires that you [add your repository to Coveralls](https://github.com/acquia/orca/blob/master/docs/faq.md#how-do-i-add-my-github-repository-to-coveralls). It is recommended to [enable notifications](https://docs.coveralls.io/coveralls-notifications). Test coverage generation greatly increases build times, so only enable it on one job--all that makes sense anyway. Note: [`ORCA_COVERAGE_ENABLE`](#ORCA_COVERAGE_ENABLE) is implied by this setting and need not be enabled if this is.
 

--- a/src/Console/Command/Debug/Helper/EnvVarsTableBuilder.php
+++ b/src/Console/Command/Debug/Helper/EnvVarsTableBuilder.php
@@ -17,7 +17,7 @@ class EnvVarsTableBuilder {
    *
    * @var \Acquia\Orca\Helper\EnvFacade
    */
-  private $env;
+  private $envFacade;
 
   /**
    * Constructs an instance.
@@ -26,7 +26,7 @@ class EnvVarsTableBuilder {
    *   The ENV facade.
    */
   public function __construct(EnvFacade $env_facade) {
-    $this->env = $env_facade;
+    $this->envFacade = $env_facade;
   }
 
   /**
@@ -55,7 +55,7 @@ class EnvVarsTableBuilder {
     foreach ($this->getVars() as $var) {
       $rows[] = [
         $var->getKey(),
-        $this->env->get($var->getKey()) ?: '~',
+        $this->envFacade->get($var->getKey()) ?: '~',
         $var->getDescription(),
       ];
     }

--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -222,7 +222,7 @@ class PhpUnitTask extends TestFrameworkBase {
         'phpunit',
         '--verbose',
       ];
-      if ($this->isToGenerateCodeCoverage()) {
+      if ($this->shouldGenerateCodeCoverage()) {
         $command[] = "--coverage-clover={$this->cloverCoverage}";
       }
       $command = array_merge($command, [

--- a/src/Domain/Tool/TestFrameworkBase.php
+++ b/src/Domain/Tool/TestFrameworkBase.php
@@ -41,7 +41,7 @@ abstract class TestFrameworkBase extends TaskBase implements TestFrameworkInterf
    * @return bool
    *   TRUE to generate code coverage or FALSE not to.
    */
-  protected function isToGenerateCodeCoverage(): bool {
+  protected function shouldGenerateCodeCoverage(): bool {
     return $this->isToGenerateCodeCoverage;
   }
 

--- a/tests/Domain/Tool/TestRunnerTest.php
+++ b/tests/Domain/Tool/TestRunnerTest.php
@@ -8,27 +8,30 @@ use Acquia\Orca\Domain\Server\ServerStack;
 use Acquia\Orca\Domain\Tool\Phpunit\PhpUnitTask;
 use Acquia\Orca\Domain\Tool\TaskInterface;
 use Acquia\Orca\Domain\Tool\TestRunner;
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem $filesystem
+ * @property \Acquia\Orca\Helper\EnvFacade|\Prophecy\Prophecy\ObjectProphecy $envFacade
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Domain\Fixture\FixtureResetter $fixtureResetter
- * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Console\Style\SymfonyStyle $output
- * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Domain\Tool\Phpunit\PhpUnitTask $phpunit
- * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Helper\Process\ProcessRunner $processRunner
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Domain\Package\PackageManager $packageManager
  * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Domain\Server\ServerStack $serverStack
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Domain\Tool\Phpunit\PhpUnitTask $phpunit
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Acquia\Orca\Helper\Process\ProcessRunner $processRunner
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Console\Style\SymfonyStyle $output
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem $filesystem
  */
 class TestRunnerTest extends TestCase {
 
-  private const PATH = 'var/www/example';
+  private const PATH = '/var/www/example';
 
   private const STATUS_MESSAGE = 'Printing status message';
 
-  protected function setUp() {
+  protected function setUp(): void {
+    $this->envFacade = $this->prophesize(EnvFacade::class);
     $this->filesystem = $this->prophesize(Filesystem::class);
     $this->fixtureResetter = $this->prophesize(FixtureResetter::class);
     $this->output = $this->prophesize(SymfonyStyle::class);
@@ -39,13 +42,14 @@ class TestRunnerTest extends TestCase {
   }
 
   private function createTestRunner(): TestRunner {
+    $env_facade = $this->envFacade->reveal();
     $filesystem = $this->filesystem->reveal();
     $fixture_resetter = $this->fixtureResetter->reveal();
     $output = $this->output->reveal();
     $phpunit = $this->phpunit->reveal();
     $package_manager = $this->packageManager->reveal();
     $server_stack = $this->serverStack->reveal();
-    return new TestRunner($filesystem, $fixture_resetter, $output, $phpunit, $package_manager, $server_stack);
+    return new TestRunner($env_facade, $filesystem, $fixture_resetter, $output, $phpunit, $package_manager, $server_stack);
   }
 
   public function testTaskRunner(): void {


### PR DESCRIPTION
This fixes the test runner trying to generate code coverage regardless of the `$ORCA_COVERAGE_ENABLE` environment variable.