### PR TITLE
Update phpmd to 2.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php-parallel-lint/php-console-highlighter": "^0.4.0",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "phploc/phploc": "^5.0",
-        "phpmd/phpmd": "^2.6",
+        "phpmd/phpmd": "^2.9.1",
         "stecman/symfony-console-completion": "^0.10.1",
         "symfony/config": "^4.1",
         "symfony/console": "^4.1",


### PR DESCRIPTION
Content Hub's most recent static analysis improvements are blocked on an error (https://travis-ci.com/github/acquia/acquia_contenthub/jobs/464126513) caused by phpmd failing to properly handle reflection classes (as best as I can tell). According to this, it should be fixed in 2.9.1 - https://github.com/phpmd/phpmd/issues/816#issuecomment-687215399