### PR TITLE
Fix command not found error in before_cache.sh

### DIFF
--- a/bin/travis/before_cache.sh
+++ b/bin/travis/before_cache.sh
@@ -9,6 +9,8 @@
 # DESCRIPTION
 #     Reserved for future use.
 
+cd "$(dirname "$0")" || exit; source _includes.sh
+
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB before_cache $ORCA_SUT_NAME"
 fi


### PR DESCRIPTION
This script produces a harmless but potentially confusing error: https://travis-ci.com/github/acquia/automatic-updater/jobs/481387635#L2229

> ../orca/bin/travis/before_cache.sh: line 13: orca: command not found
