### PR TITLE
Make sed command in example .travis.yml more cross-platform portable

### DIFF
--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -14,7 +14,7 @@
 #
 # 4. Strip the (now unnecessary) comments:
 #
-#    $ sed -i '' '/^[[:blank:]]*#/d;s/#.*//' .travis.yml
+#    $ sed -i'.bak' -e '/^[[:blank:]]*#/d;s/#.*//' .travis.yml && rm .travis.yml.bak
 #
 # For advanced needs,
 # @see https://github.com/acquia/orca/blob/master/docs/advanced-usage.md


### PR DESCRIPTION
The provided sed command works on Mac but fails on Unix (e.g. Ubuntu).

Mac uses BSD sed, which has slightly different syntax than Unix. This is the most succinct cross-platform compatible command.