### PR TITLE
Add acquia/drupal-environment-detector to packages

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -104,7 +104,7 @@ acquia/coding-standards:
   url: ../coding-standards-php
 
 acquia/drupal-environment-detector:
-  type: package
+  type: library
   version_dev: "dev-master"
 
 drupal/cog:

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -103,6 +103,10 @@ acquia/coding-standards:
   type: phpcodesniffer-standard
   url: ../coding-standards-php
 
+acquia/drupal-environment-detector:
+  type: package
+  version_dev: "dev-master"
+
 drupal/cog:
   type: drupal-theme
   core_matrix:

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -105,7 +105,6 @@ acquia/coding-standards:
 
 acquia/drupal-environment-detector:
   type: library
-  version_dev: "dev-master"
 
 drupal/cog:
   type: drupal-theme


### PR DESCRIPTION
The environment detector has been integrated with ORCA for some time, it would be nice to include it in integrated tests and not maintain a packages_alter: https://github.com/acquia/drupal-environment-detector/blob/master/tests/packages_alter.yml