### PR TITLE
Exclude MissingImport rule from PHPMD

### DIFF
--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -11,6 +11,7 @@
     <exclude name="BooleanArgumentFlag"/>
     <exclude name="ElseExpression"/>
     <exclude name="StaticAccess"/>
+    <exclude name="MissingImport"/>
   </rule>
   <rule ref="rulesets/codesize.xml"/>
   <rule ref="rulesets/design.xml"/>


### PR DESCRIPTION
Unfortunately this rule conflicts with [Drupal's own coding standards](https://www.drupal.org/docs/develop/coding-standards/namespaces#s-use-ing-classes).

I've opened an upstream issue with PHPMD to try to reconcile this: https://github.com/phpmd/phpmd/issues/868