### PR TITLE
Update versions of drupal/acquia_connector and drupal/acquia_search in packages.yml

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -48,13 +48,8 @@
 # example.
 
 drupal/acquia_connector:
-  core_matrix:
-    '>=9':
-      version: 2.x
-      version_dev: 2.x-dev
-    '*':
-      version: 1.x
-      version_dev: 1.x
+  version: 3.x
+  version_dev: 3.x-dev
 
 drupal/acquia_contenthub:
   core_matrix:
@@ -85,10 +80,9 @@ drupal/acquia_purge:
 
 drupal/acsf: []
 
-drupal/acquia_search_solr:
-  # This module will never support D8. It should be installable on D9 soon.
-  version: ~
-  version_dev: ~
+drupal/acquia_search:
+  version: 3.x
+  version_dev: 3.x-dev
 
 acquia/blt:
   type: composer-plugin


### PR DESCRIPTION
Acquia Search replaces Acquia Search Solr. It uses semantic versioning and only supports Drupal 8.9+
Connector 3.x also uses semantic versioning and only supports Drupal 8.9+

Hopefully we don't need to support Drupal 8.8?