### PR TITLE
Prevent scripts from using the wrong Composer version on Travis CI

### DIFF
--- a/bin/travis/_includes.sh
+++ b/bin/travis/_includes.sh
@@ -72,6 +72,8 @@ export PATH="$ORCA_ROOT/bin:$PATH"
 export PATH="$ORCA_ROOT/vendor/bin:$PATH"
 export PATH="$ORCA_FIXTURE_DIR/vendor/bin:$PATH"
 export PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+# Put this last to ensure that the host's Composer is preferred.
+export PATH="$HOME/.phpenv/shims/:$PATH"
 
 # Add convenient aliases.
 alias drush='drush -r "$ORCA_FIXTURE_DIR"'


### PR DESCRIPTION
This prevents the wrong Composer install from being used within custom scripts. A common symptom of using the wrong one is an error like the below, which shows that the wrong version (1.x) is being executed.

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - acquia/blt 12.8.2 requires composer-plugin-api ^2.0 -> no matching package found.
    - acquia/blt 12.8.2 requires composer-plugin-api ^2.0 -> no matching package found.
    - acquia/blt 12.8.2 requires composer-plugin-api ^2.0 -> no matching package found.
    - Installation request for acquia/blt 12.8.2 -> satisfiable by acquia/blt[12.8.2].
```