### PR TITLE
Remove travis Ruby gem

### DIFF
--- a/bin/travis/after_script.sh
+++ b/bin/travis/after_script.sh
@@ -24,8 +24,3 @@ if [[ "$ORCA_TELEMETRY_ENABLE" = "TRUE" ]]; then
 else
   notice "No telemetry data sent."
 fi
-
-# Show ORCA's own current build status. A failure may signify an upstream issue
-# or service level outage that could have affected this build.
-# @see https://travis-ci.org/acquia/orca/branches
-echo && travis history --no-interactive --repo=acquia/orca --branch=master --limit=2 --date

--- a/bin/travis/before_install.sh
+++ b/bin/travis/before_install.sh
@@ -41,9 +41,6 @@ yes | pecl install yaml
 # Display PHP information.
 php -i
 
-# Install Travis command line client.
-gem install travis
-
 # Download and install ORCA libraries if necessary. This provides compatibility
 # with the old method of installing ORCA via `git clone` rather than the newer
 # `composer create-project` approach.


### PR DESCRIPTION
The `travis` Ruby gem recently caused universal build failures with the error depicted below. There's no reason to accept a dependency we can't control for a feature that adds so little value comparatively. Remove it.

```
# Install Travis command line client.
gem install travis
ERROR:  While executing gem ... (Gem::Resolver::Molinillo::CircularDependencyError)
    There is a circular dependency between faraday-net_http_persistent and faraday
The command "../orca/bin/travis/before_install.sh" failed and exited with 1 during .
```