### PR TITLE
Fix Drupal core 9.3.x becoming NEXT_MINOR_DEV too soon

### DIFF
--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -292,9 +292,21 @@ class DrupalCoreVersionResolver {
     }
 
     $this->nextMinor = $this
-      ->resolveArbitrary(">{$this->findCurrent()}", 'alpha', FALSE);
+      ->resolveArbitrary("~{$this->findNextMinorUnresolved()}", 'alpha', FALSE);
 
     return $this->nextMinor;
+  }
+
+  /**
+   * Finds the next minor version unresolved, e.g., 9.2.0 for 9.1.7.
+   *
+   * @return string
+   *   The semver string.
+   */
+  private function findNextMinorUnresolved(): string {
+    $current_minor = (float) ($this->findCurrent());
+    $current_minor = (string) ($current_minor + 0.1);
+    return "{$current_minor}.0";
   }
 
   /**
@@ -310,12 +322,8 @@ class DrupalCoreVersionResolver {
       return $this->nextMinorDev;
     }
 
-    // Constrain the version to "<9999999-dev" to work around a bug in Composer
-    // that treated 8.9 as greater than 9.2 at the time of this writing.
-    // @see https://github.com/composer/composer/issues/9705
-    $version = ">{$this->findCurrent()} <9999999-dev";
-    $this->nextMinorDev = $this
-      ->resolveArbitrary($version, 'dev', TRUE);
+    $next_minor = $this->findNextMinorUnresolved();
+    $this->nextMinorDev = $this->convertToDev($next_minor);
 
     return $this->nextMinorDev;
   }

--- a/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
+++ b/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
@@ -250,7 +250,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
       ->getPrettyVersion()
       ->willReturn('9.1.0', '9.2.0-alpha1')
       ->shouldBeCalledTimes(2);
-    $this->selector->findBestCandidate('drupal/core', '>9.1.0', 'alpha')
+    $this->selector->findBestCandidate('drupal/core', '~9.2.0', 'alpha')
       ->willReturn($this->package->reveal())
       ->shouldBeCalledOnce();
     $resolver = $this->createDrupalCoreVersionResolver();
@@ -266,8 +266,8 @@ class DrupalCoreVersionResolverTest extends TestCase {
     $this->expectGetCurrentToBeCalledOnce();
     $this->package
       ->getPrettyVersion()
-      ->willReturn('9.2.x-dev');
-    $this->selector->findBestCandidate('drupal/core', '>9.1.0', 'dev')
+      ->willReturn('9.1.x-dev');
+    $this->selector->findBestCandidate('drupal/core', '*', 'stable')
       ->willReturn($this->package->reveal());
     $resolver = $this->createDrupalCoreVersionResolver();
 
@@ -331,7 +331,11 @@ class DrupalCoreVersionResolverTest extends TestCase {
 
   public function providerResolvePredefinedVersionNotFound(): array {
     $data = $this->providerVersions();
-    unset($data[DrupalCoreVersionEnum::CURRENT], $data[DrupalCoreVersionEnum::CURRENT_DEV]);
+    unset(
+      $data[DrupalCoreVersionEnum::CURRENT],
+      $data[DrupalCoreVersionEnum::CURRENT_DEV],
+      $data[DrupalCoreVersionEnum::NEXT_MINOR_DEV]
+    );
     return $data;
   }
 


### PR DESCRIPTION
This fixes the `DrupalCoreVersionResolver` identifying  a new minor version branch as `NEXT_MINOR_DEV` before the previous minor has become `CURRENT_DEV`.