### PR TITLE
Add "qa:automated-tests --all" command option

### DIFF
--- a/src/Console/Command/Qa/QaAutomatedTestsCommand.php
+++ b/src/Console/Command/Qa/QaAutomatedTestsCommand.php
@@ -23,6 +23,13 @@ class QaAutomatedTestsCommand extends Command {
   protected static $defaultName = 'qa:automated-tests';
 
   /**
+   * The "all" command line option.
+   *
+   * @var bool
+   */
+  private $all;
+
+  /**
    * The fixture path handler.
    *
    * @var \Acquia\Orca\Helper\Filesystem\FixturePathHandler
@@ -84,12 +91,13 @@ class QaAutomatedTestsCommand extends Command {
   /**
    * {@inheritdoc}
    */
-  protected function configure() {
+  protected function configure(): void {
     $this
       ->setAliases(['test'])
       ->setDescription('Runs automated tests')
       ->addOption('sut', NULL, InputOption::VALUE_REQUIRED, 'The system under test (SUT) in the form of its package name, e.g., "drupal/example"')
       ->addOption('sut-only', NULL, InputOption::VALUE_NONE, 'Run tests from only the system under test (SUT). Omit tests from all other company packages')
+      ->addOption('all', NULL, InputOption::VALUE_NONE, 'Run all tests, public and private (always true for the system under test (SUT))')
       ->addOption('phpunit', NULL, InputOption::VALUE_NONE, 'Run only PHPUnit tests')
       ->addOption('no-servers', NULL, InputOption::VALUE_NONE, "Don't run the ChromeDriver and web servers");
   }
@@ -101,6 +109,7 @@ class QaAutomatedTestsCommand extends Command {
     $this->noServers = $input->getOption('no-servers');
     $this->sut = $input->getOption('sut');
     $this->sutOnly = $input->getOption('sut-only');
+    $this->all = $input->getOption('all');
 
     if (!$this->isValidInput($output)) {
       return StatusCodeEnum::ERROR;
@@ -162,6 +171,10 @@ class QaAutomatedTestsCommand extends Command {
 
     if ($this->sutOnly) {
       $this->testRunner->setSutOnly(TRUE);
+    }
+
+    if ($this->all) {
+      $this->testRunner->setRunAllTests(TRUE);
     }
 
     if ($this->noServers) {

--- a/src/Domain/Tool/TestRunner.php
+++ b/src/Domain/Tool/TestRunner.php
@@ -63,6 +63,13 @@ class TestRunner {
   private $phpunit;
 
   /**
+   * The run all tests flag.
+   *
+   * @var bool
+   */
+  private $runAllTests;
+
+  /**
    * The run PHPUnit flag.
    *
    * @var bool
@@ -141,6 +148,16 @@ class TestRunner {
   }
 
   /**
+   * Sets the run all tests flag.
+   *
+   * @param bool $run_all_tests
+   *   TRUE to run all tests or FALSE not to.
+   */
+  public function setRunAllTests(bool $run_all_tests): void {
+    $this->runAllTests = $run_all_tests;
+  }
+
+  /**
    * Sets the run PHPUnit flag.
    *
    * @param bool $run_phpunit
@@ -193,7 +210,7 @@ class TestRunner {
         continue;
       }
       foreach ($this->getFrameworks() as $framework) {
-        $this->execute($framework, $package, TRUE);
+        $this->execute($framework, $package, !$this->runAllTests);
       }
     }
   }

--- a/tests/Console/Command/Qa/QaAutomatedTestsCommandTest.php
+++ b/tests/Console/Command/Qa/QaAutomatedTestsCommandTest.php
@@ -31,6 +31,7 @@ class QaAutomatedTestsCommandTest extends CommandTestBase {
       ->willReturn(self::FIXTURE_ROOT);
     $this->packageManager = $this->prophesize(PackageManager::class);
     $this->testRunner = $this->prophesize(TestRunner::class);
+    $this->testRunner->run();
   }
 
   protected function createCommand(): Command {
@@ -107,6 +108,30 @@ class QaAutomatedTestsCommandTest extends CommandTestBase {
     return [
       [[], 0],
       [['--phpunit' => 1], 0],
+    ];
+  }
+
+  /**
+   * @dataProvider providerAllOption
+   */
+  public function testAllOption($args, $call_count): void {
+    $this->testRunner
+      ->setRunAllTests(TRUE)
+      ->shouldBeCalledTimes($call_count);
+
+    $this->executeCommand($args);
+  }
+
+  public function providerAllOption(): array {
+    return [
+      [
+        'args' => [],
+        'call_count' => 0,
+      ],
+      [
+        'args' => ['--all' => TRUE],
+        'call_count' => 1,
+      ],
     ];
   }
 


### PR DESCRIPTION
This adds a new `--all` option to the `qa:automated-tests` command, which causes [integrated tests](https://github.com/acquia/orca/blob/develop/docs/glossary.md#integrated-test) to run all packages' [public](https://github.com/acquia/orca/blob/develop/docs/glossary.md#public-tests) _and_ [private](https://github.com/acquia/orca/blob/develop/docs/glossary.md#private-tests) tests--all except [ignored](https://github.com/acquia/orca/blob/develop/docs/glossary.md#ignored-tests). This is useful for comprehensive, centralized testing of the entire packages suite. Note, however, that it will almost certainly fail every time if any package's private tests depend on a custom fixture. In that case, the offending packages can be [altered out](https://github.com/acquia/orca/blob/develop/docs/advanced-usage.md#ORCA_PACKAGES_CONFIG_ALTER). Otherwise test results will have to be manually inspected and interpreted.