### PR TITLE
Add a PHP 8 Travis CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, name: "Integrated test on previous minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR, name: "Integrated upgrade test from previous minor Drupal core version" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT ORCA_ENABLE_NIGHTWATCH=TRUE, name: "Isolated test on current Drupal core version with Nightwatch.js" }
+    - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT ORCA_ENABLE_NIGHTWATCH=TRUE, php: "8.0", dist: focal, name: "Isolated test on current Drupal core version and PHP 8 with Nightwatch.js" }
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_CURRENT, name: "Integrated test on current Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR, name: "Integrated upgrade test to next minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV, name: "Integrated upgrade test to next minor dev Drupal core version" }
@@ -70,7 +71,7 @@ jobs:
     - env: ORCA_LIVE_TEST=TRUE
 
 before_install:
-  - nvm use 12.13.1
+  - nvm install 12.13.1; nvm use 12.13.1
   - ../orca/bin/travis/self-test/before_install.sh
   - ../orca/bin/travis/before_install.sh
 

--- a/bin/travis/before_install.sh
+++ b/bin/travis/before_install.sh
@@ -44,7 +44,7 @@ php -i
 # Download and install ORCA libraries if necessary. This provides compatibility
 # with the old method of installing ORCA via `git clone` rather than the newer
 # `composer create-project` approach.
-[[ -d "$ORCA_ROOT/vendor" ]] || composer -d"$ORCA_ROOT" install
+[[ -d "$ORCA_ROOT/vendor" ]] || composer -d"$ORCA_ROOT" --ignore-platform-req=php install
 
 # Display ORCA version and configuration values.
 orca --version

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -111,6 +111,7 @@ jobs:
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, name: "Integrated test on previous minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR, name: "Integrated upgrade test from previous minor" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT, name: "Isolated test on current Drupal core version" }
+    - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT, php: "8.0", dist: focal, name: "Isolated test on current Drupal core version and PHP 8" }
     # To send PHPUnit test coverage data to Coveralls (coveralls.io), configure
     # your GitHub repository according to the FAQ below and uncomment the
     # following line. By default this job is allowed to fail (see below) so that
@@ -164,8 +165,8 @@ jobs:
 # Install ORCA and prepare the environment.
 before_install:
   # Set Node.js to a version compatible with Drupal 9 + Nightwatch.js.
-  - nvm use 12.13.1
-  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
+  - nvm install 12.13.1; nvm use 12.13.1
+  - composer create-project --no-dev --ignore-platform-req=php acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
   # For custom testing needs, add your own scripts here. See the example script
   # for more details.


### PR DESCRIPTION
This makes ORCA installable on PHP 8 and adds a PHP 8 build job. To get the new job, update your `.travis.yml` as follows:

```diff
@@ -111,6 +111,7 @@ jobs:
     - { env: ORCA_JOB=INTEGRATED_TEST_ON_PREVIOUS_MINOR, name: "Integrated test on previous minor Drupal core version" }
     - { env: ORCA_JOB=INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR, name: "Integrated upgrade test from previous minor" }
     - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT, name: "Isolated test on current Drupal core version" }
+    - { env: ORCA_JOB=ISOLATED_TEST_ON_CURRENT, php: "8.0", dist: focal, name: "Isolated test on current Drupal core version and PHP 8" }
     # To send PHPUnit test coverage data to Coveralls (coveralls.io), configure
     # your GitHub repository according to the FAQ below and uncomment the
     # following line. By default this job is allowed to fail (see below) so that
@@ -164,8 +165,8 @@ jobs:
 # Install ORCA and prepare the environment.
 before_install:
   # Set Node.js to a version compatible with Drupal 9 + Nightwatch.js.
-  - nvm use 12.13.1
-  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
+  - nvm install 12.13.1; nvm use 12.13.1
+  - composer create-project --no-dev --ignore-platform-req=php acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
   # For custom testing needs, add your own scripts here. See the example script
   # for more details.

```