### PR TITLE
Documentation fix for Composer constraint conflicts with Acquia CMS

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,6 +32,23 @@ ORCA doesn't install dev dependencies because Composer provides no means of doin
 
 1. Simply "ignore" tests with unique dependencies and run them apart from ORCA. See [Running automated tests](getting-started.md#tagginggrouping).
 
+### Why do I get version conflicts with drupal/acquia_cms?
+
+As an opinionated [project template](#project-template), [Acquia CMS](glossary.md#acquia-cms) (`drupal/acquia_cms`) has very tight version constraints that can conflict with your dependencies as depicted in this example error:
+
+   ```
+   Problem 1
+     - acquia/acquia_cms[v1.2-rc1, ..., 1.2.5.x-dev] require drupal/acquia_connector ^3 -> satisfiable by drupal/acquia_connector[dev-3.x, 3.0.0-rc1, ..., 3.x-dev (alias of dev-3.x)] from composer repo (https://packages.drupal.org/8) but drupal/acquia_connector[dev-8.x-1.x, 1.x-dev (alias of dev-8.x-1.x)] from path repo (/home/travis/build/acquia/acquia_connector) has higher repository priority. The packages with higher priority do not match your constraint and are therefore not installable. See https://getcomposer.org/repoprio for details and assistance.
+   ```
+
+Acquia CMS is included in ORCA [test fixtures](glossary.md#test-fixture) by default by way of a requirement in [Acquia Drupal Recommended Project](glossary.md#acquia-drupal-recommended-project). If your package or one of its version branches is not meant to support Acquia CMS, you should use a different [project template](glossary.md#project-template). Add the following to your `.travis.yml` to do so on Travis CI:
+
+   ```yaml
+   env:
+     global:
+       - ORCA_FIXTURE_PROJECT_TEMPLATE=acquia/drupal-minimal-project
+   ```
+
 ## Coveralls
 
 ### How do I add my GitHub repository to Coveralls?

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,6 @@
 # Project Glossary
 
+* [Acquia CMS](#acquia-cms)
 * [Bare fixture](#bare-fixture)
 * [BLT](#blt)
 * [Fixture](#test-fixture)
@@ -15,6 +16,7 @@
 * [Plumbing interface](#orca-internals)
 * [Porcelain interface](#orca-internals)
 * [Private tests](#private-tests)
+* [Project template](#project-template)
 * [Public tests](#public-tests)
 * [Standard fixture](#standard-fixture)
 * [SUT](#sut)
@@ -22,6 +24,10 @@
 * [SUT-only fixture](#sut-only-fixture)
 * [System Under Test](#sut)
 * [Test fixture](#test-fixture)
+
+## Acquia CMS
+
+[Acquia CMS](https://www.drupal.org/project/acquia_cms) (`drupal/acquia_cms`) is Acquia's opinionated Drupal distribution for running low-code websites on the Acquia hosting platform. It is included in ORCA [test fixtures](#test-fixture) by default by way of [Drupal Recommended Project](#project-template). Cf. [Why do I get version conflicts with drupal/acquia_cms?](faq.md#why-do-i-get-version-conflicts-with-drupalacquia_cms).
 
 ## Bare fixture
 
@@ -70,6 +76,27 @@ A programmer-oriented testing framework used by Drupal. [[Website]](https://phpu
 ## Private tests
 
 Automated tests that ORCA runs only when the package that provides them is the [SUT](#sut). Any test that is not designated [public](#public-tests) or [ignored](#ignored-tests) is automatically treated as private. [Read more in Running automated tests: Tagging/grouping.](getting-started.md#tagginggrouping)
+
+## Project template
+
+A project template is a way to use Composer to create new projects from an existing package. See [composer create-project](https://getcomposer.org/doc/03-cli.md#create-project). In Drupal 8 and later, this is the preferred way to manage Drupal and all dependencies (modules, themes, libraries). See [Using Composer to Install Drupal and Manage Dependencies](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies). Acquia provides two project templates:
+
+* <a name="acquia-drupal-recommended-project"</a>[**Acquia Drupal Recommended Project**](https://github.com/acquia/drupal-recommended-project) (`acquia/drupal-recommended-project`) is a project template providing a great out-of-the-box experience for new Drupal 9 projects hosted on Acquia.
+* <a name="acquia-drupal-minimal-project"</a>[**Acquia Drupal Minimal Project**](https://github.com/acquia/drupal-minimal-project) (`acquia/drupal-minimal-project`) provides a minimal Drupal application to be hosted on Acquia.
+
+By default, ORCA uses Acquia Drupal Recommended Project to create [test fixtures](#test-fixture). This behavior can be changed using the `--project-template` option of the [`fixture:init`](advanced-usage.md#fixtureinit) Console command like this, for example:
+
+   ```shell
+   orca fixture:init --project-template=acquia/drupal-minimal-project
+   ```
+
+On Travis CI, it can be changed via the [`ORCA_FIXTURE_PROJECT_TEMPLATE`](advanced-usage.md#ORCA_FIXTURE_PROJECT_TEMPLATE) environment variable in your `.travis.yml` like this:
+
+   ```yaml
+   env:
+     global:
+       - ORCA_FIXTURE_PROJECT_TEMPLATE=acquia/drupal-minimal-project
+   ```
 
 ## Public tests
 

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -81,8 +81,10 @@ env:
     #
     # If your package is a Composer project template or requires a different
     # one to test with, uncomment the following line and specify its Packagist
-    # name.
+    # name. This is recommended if your package is not meant to support Acquia
+    # CMS, which is included in acquia/drupal-recommended-project.
     # @see https://github.com/acquia/orca/blob/main/docs/advanced-usage.md#ORCA_FIXTURE_PROJECT_TEMPLATE
+    # @see https://github.com/acquia/orca/blob/main/docs/faq.md#why-do-i-get-version-conflicts-with-drupalacquia_cms
     # - ORCA_FIXTURE_PROJECT_TEMPLATE=acquia/drupal-minimal-project
     #
     # Change the PHP Code Sniffer standard used for static analysis. Acceptable


### PR DESCRIPTION
Due to Acquia CMS's tight version constraints, some packages may encounter Composer version conflicts with it, as below:

```
  Problem 1
    - acquia/acquia_cms[v1.2-rc1, ..., 1.2.5.x-dev] require drupal/acquia_connector ^3 -> satisfiable by drupal/acquia_connector[dev-3.x, 3.0.0-rc1, ..., 3.x-dev (alias of dev-3.x)] from composer repo (https://packages.drupal.org/8) but drupal/acquia_connector[dev-8.x-1.x, 1.x-dev (alias of dev-8.x-1.x)] from path repo (/home/travis/build/acquia/acquia_connector) has higher repository priority. The packages with higher priority do not match your constraint and are therefore not installable. See https://getcomposer.org/repoprio for details and assistance.
```

This can be easily worked around on Travis CI by adding the following to your `.travis.yml`:

```yaml
env:
  global:
    - ORCA_FIXTURE_PROJECT_TEMPLATE=acquia/drupal-minimal-project
```

See https://github.com/acquia/orca/blob/ec8ea5abd0da003c280fae67e60a264b5cb0ee2a/docs/faq.md#why-do-i-get-version-conflicts-with-drupalacquia_cms.