### PR TITLE
Stop on errors in _includes.sh

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -9,9 +9,8 @@
 # DESCRIPTION
 #     Includes common features used by ORCA scripts.
 
-# Exit as soon as one command returns a non-zero exit code and make the shell
-# print all lines in the script before executing them.
-set -ev
+# Exit as soon as one command returns a non-zero exit code.
+set -e
 
 # Outputs a formatted error message and exits with an error code if a given
 # condition is not met.

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -93,3 +93,6 @@ export PATH="$HOME/.phpenv/shims/:$PATH"
 
 # Add convenient aliases.
 alias drush='drush -r "$ORCA_FIXTURE_DIR"'
+
+# Make the shell print all lines in the script before executing them.
++ set -v

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -9,6 +9,10 @@
 # DESCRIPTION
 #     Includes common features used by ORCA scripts.
 
+# Exit as soon as one command returns a non-zero exit code and make the shell
+# print all lines in the script before executing them.
+set -ev
+
 # Outputs a formatted error message and exits with an error code if a given
 # condition is not met.
 function assert {
@@ -90,7 +94,3 @@ export PATH="$HOME/.phpenv/shims/:$PATH"
 
 # Add convenient aliases.
 alias drush='drush -r "$ORCA_FIXTURE_DIR"'
-
-# Exit as soon as one command returns a non-zero exit code and make the shell
-# print all lines in the script before executing them.
-set -ev

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -95,4 +95,4 @@ export PATH="$HOME/.phpenv/shims/:$PATH"
 alias drush='drush -r "$ORCA_FIXTURE_DIR"'
 
 # Make the shell print all lines in the script before executing them.
-+ set -v
+set -v


### PR DESCRIPTION
Katherine and I completely missed a syntax error while working _includes.sh, because Bash doesn't exit immediately upon errors.

@TravisCarden do you recall why you only `set -e` at the _end_ of _includes.sh, rather than the beginning?