### PR TITLE
only run after_failure if ORCA_JOB is set

### DIFF
--- a/bin/ci/after_failure.sh
+++ b/bin/ci/after_failure.sh
@@ -15,4 +15,6 @@ if [[ -f "$ORCA_FIXTURE_DIR/vendor/bin/drush" && "$(drush core-status --field=bo
   drush watchdog:show --count=100 --severity=Error --extended
 fi
 
-eval "orca ci:run $ORCA_JOB after_failure $ORCA_SUT_NAME"
+if [[ "$ORCA_JOB" ]]; then
+  eval "orca ci:run $ORCA_JOB after_failure $ORCA_SUT_NAME"
+fi


### PR DESCRIPTION
All other scripts in the `bin` directory use a guard to check if ORCA_JOB is set before invoking ORCA commands.

Because this isn't guarded and ORCA's live test does not specify an ORCA_JOB, live tests fail.

@TravisCarden you can see the live job is now passing. We'll fix the failing deprecated code scan separately, as discussed.