### PR TITLE
Add project templates

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -117,6 +117,12 @@ drupal/cog:
 acquia/drupal-environment-detector:
   type: library
 
+acquia/drupal-minimal-project:
+  type: project-template
+
+acquia/drupal-recommended-project:
+  type: project-template
+
 acquia/drupal-spec-tool:
   type: behat-extension
   core_matrix:


### PR DESCRIPTION
This shouldn't have any functional impact on ORCA consumers, but it will allow us to remove the config overrides from the templates.