### PR TITLE
Use drupal-minimal-project for isolated tests

### DIFF
--- a/src/Options/FixtureOptions.php
+++ b/src/Options/FixtureOptions.php
@@ -296,14 +296,27 @@ class FixtureOptions {
    *   The package name.
    */
   public function getProjectTemplate(): string {
+    // Allow users to override default templates via option.
     if ($this->options['project-template']) {
       return $this->options['project-template'];
     }
+
+    // The new project templates only support D9+. Use BLT Project for D8.
+    // @todo remove D8 / BLT Project support after D8 EOL in November 2021.
     if (Comparator::lessThan($this->getCoreResolved(), '9')) {
       $this->options['project-template'] = 'acquia/blt-project';
       return $this->options['project-template'];
     }
-    $this->options['project-template'] = 'acquia/drupal-recommended-project';
+
+    // Use minimal project for SUT-only (i.e. isolated) jobs, which should have
+    // no other company packages.
+    if ($this->isSutOnly()) {
+      $this->options['project-template'] = 'acquia/drupal-minimal-project';
+    }
+    else {
+      $this->options['project-template'] = 'acquia/drupal-recommended-project';
+    }
+
     return $this->options['project-template'];
   }
 


### PR DESCRIPTION
Isolated jobs currently use acquia/drupal-recommended-project as a fixture. This is problematic because drupal-recommended-project requires ACMS, and therefore essentially every company package. This defeats the purpose of an isolated build, which is to catch any undeclared dependency (including Composer dependencies) for a SUT.

This is a regression caused by the switch from Lightning to Acquia CMS. With Lightning, isolated tests included minimal dependencies (despite using the same template) because ORCA explicitly removed Lightning from the fixture before re-adding the SUT.

Happily, this also fixes that last failing deprecated code scan job, so the build is green again. (It was scanning all of the contrib modules from drupal-recommend-project).