### PR TITLE
Don't run tests for project templates

### DIFF
--- a/src/Domain/Tool/TestRunner.php
+++ b/src/Domain/Tool/TestRunner.php
@@ -202,6 +202,11 @@ class TestRunner {
     $message = ($this->sut) ? 'Running public non-SUT tests' : 'Running all public tests';
     $this->output->title($message);
     foreach ($this->packageManager->getAll() as $package) {
+      // Project templates don't provide tests... yet. Attemping to run them
+      // right now would run all Drupal contrib tests.
+      if ($package->isProjectTemplate()) {
+        continue;
+      }
       if ($this->sut && $package->getPackageName() === $this->sut->getPackageName()) {
         continue;
       }


### PR DESCRIPTION
It seems like when ORCA tries to run tests for project templates, it runs _all_ contrib tests, which is obviously bad for many reasons, not least of which is because many of those tests are broken.

- https://github.com/danepowell/drupal-recommended-project/runs/3736913097?check_suite_focus=true#step:8:161
- https://github.com/danepowell/drupal-environment-detector/runs/3736871443?check_suite_focus=true
- https://github.com/danepowell/drupal-minimal-project/runs/3736266508?check_suite_focus=true

Confirming that this fixes the failure:
- https://github.com/danepowell/drupal-recommended-project/runs/3737179990?check_suite_focus=true