### PR TITLE
Xdebug never disabled on Travis CI

### DIFF
--- a/bin/ci/before_install.sh
+++ b/bin/ci/before_install.sh
@@ -24,9 +24,18 @@ echo "$TRAVIS_NODE_VERSION"
 yarn --version
 
 # Disable Xdebug except on code coverage jobs.
-if [[ ! "$ORCA_COVERAGE_ENABLE" ]]; then
+if [[ ! "$ORCA_COVERAGE_ENABLE" == TRUE ]]; then
   if [[ "$TRAVIS" ]]; then phpenv config-rm xdebug.ini; fi
-  if [[ "$GITHUB_ACTIONS" ]]; then sudo phpdismod -v ALL xdebug; fi
+  if [[ "$GITHUB_ACTIONS" ]]; then
+    # phpdismod would be simpler but flaky
+    # @see https://github.com/shivammathur/setup-php/issues/350#issuecomment-735370872
+    scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
+    ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+    pecl_file="$scan_dir"/99-pecl.ini
+    sudo sed -Ei "/xdebug/d" "${ini_file:?}"
+    sudo sed -Ei "/xdebug/d" "${pecl_file:?}"
+    sudo rm -rf "$scan_dir"/*xdebug*
+  fi
 fi
 
 # Travis CI installs YAML from PECL, but it's already present in GitHub Actions.

--- a/bin/ci/self-test/script.sh
+++ b/bin/ci/self-test/script.sh
@@ -13,6 +13,17 @@ cd "$(dirname "$0")" || exit 1; source ../_includes.sh
 
 cd ../../../ || exit 1
 
+XDEBUG_IS_ENABLED=$(php -r 'echo function_exists("xdebug_get_code_coverage") ? "TRUE" : "FALSE";')
+
+if [[ "$ORCA_COVERAGE_ENABLE" == TRUE && "$XDEBUG_IS_ENABLED" == "FALSE" ]]; then
+  echo "ORCA_COVERAGE_ENABLE is on but Xdebug is disabled"
+  exit 1
+fi
+
+if [[ "$ORCA_COVERAGE_ENABLE" == FALSE && "$XDEBUG_IS_ENABLED" == "TRUE" ]]; then
+  echo "ORCA_COVERAGE_ENABLE is off but Xdebug is enabled"
+  exit 1
+fi
 
 if [[ "$ORCA_JOB" == "STATIC_CODE_ANALYSIS" ]]; then
   ./vendor/bin/phpcs


### PR DESCRIPTION
Xdebug is no longer removed when `ORCA_COVERAGE_ENABLE=FALSE`. Xdebug _is_ removed if ORCA_COVERAGE_ENABLE is empty, but I don't think that's ever the case: _includes.sh sets it to either TRUE or FALSE.

Additionally, for builds on Xenial which uses Xdebug 3, this triggers a bug in phploc. This is a regression introduced by https://github.com/acquia/orca/pull/152

- BLT PR verifying that this patch works to disable Xdebug: https://github.com/acquia/blt/pull/4403
- Upstream phplocbug: https://github.com/sebastianbergmann/phploc/issues/222
- Follow-up issue to fix Xdebug 3 compatibility: https://github.com/acquia/orca/issues/160

@TravisCarden where would be the best place to add an automated test to ensure that Xdebug is disabled when `ORCA_COVERAGE_ENABLE=FALSE`?