### PR TITLE
Remove cog theme from core packages

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -104,16 +104,6 @@ acquia/coding-standards:
   type: phpcodesniffer-standard
   url: ../coding-standards-php
 
-drupal/cog:
-  type: drupal-theme
-  core_matrix:
-    '>=9.0.0':
-      version: ~
-      version_dev: ~
-    '*':
-      version: '*'
-      version_dev: '*'
-
 acquia/drupal-environment-detector:
   type: library
 


### PR DESCRIPTION
Cog has fallen out of use and is effectively unmaintained.