### PR TITLE
Boolean environment variables broken in GitHub Actions

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -20,11 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failure }}
     env:
+      # Boolean values must be quoted, otherwise they will be converted to lower case and break ORCA scripts.
       ORCA_SUT_NAME: drupal/example
       ORCA_SUT_BRANCH: main
       ORCA_PACKAGES_CONFIG: example/tests/packages.yml
       ORCA_PACKAGES_CONFIG_ALTER: example/tests/packages_alter.yml
-      ORCA_ENABLE_NIGHTWATCH: FALSE
+      ORCA_ENABLE_NIGHTWATCH: "FALSE"
       # Hardcode path since GITHUB_WORKSPACE can't be used here.
       # @see https://github.community/t/how-to-use-env-context/16975/9
       ORCA_SUT_DIR: /home/runner/work/orca/example
@@ -73,7 +74,7 @@ jobs:
             php-version: "7.3"
             allow-failure: true
 
-          - orca-live-test: TRUE
+          - orca-live-test: "TRUE"
             php-version: "7.3"
             allow-failure: true
 

--- a/example/.github/workflows/orca.yml
+++ b/example/.github/workflows/orca.yml
@@ -36,6 +36,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
     # Change the following values for your implementation.
     env:
+      # Boolean values must be quoted, otherwise they will be converted to lower case and break ORCA scripts.
       # Provide your package's name.
       ORCA_SUT_NAME: drupal/example
       # Specify the name of the nearest Git version branch, e.g., 1.x or 8.x-1.x.
@@ -83,7 +84,7 @@ jobs:
       # line and set ORCA_AMPLITUDE_API_KEY in your GitHub Actions settings:
       # @see https://github.com/acquia/orca/blob/main/docs/advanced-usage.md#ORCA_TELEMETRY_ENABLE
       # @see https://github.com/acquia/orca/blob/main/docs/advanced-usage.md#ORCA_AMPLITUDE_API_KEY
-      # ORCA_TELEMETRY_ENABLE: TRUE
+      # ORCA_TELEMETRY_ENABLE: "TRUE"
       #
       # Do not modify the following line. It uses the build matrix to set ORCA_JOB for each job.
       ORCA_JOB: ${{ matrix.orca-job }}


### PR DESCRIPTION
YAML recognizes boolean environment variables as true booleans, and when casting to a string does so in lower case. So `TRUE` becomes `true`, `FALSE` becomes `false`. This breaks things because ORCA's shell scripts compare variables to upper-case strings, so these comparisons always fail.

This wasn't a problem on Travis CI because the yaml syntax was slightly different (an array of exports rather than an object mapping variable names to values).

The simple short-term fix is to quote all environment variable values. The better long-term fix is probably to change ORCA's shell scripts to properly handle boolean values in a case-insensitive way: https://github.com/acquia/orca/issues/170