### PR TITLE
Fix phploc scanning of projects with no code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-sqlite3": "*",
         "acquia/coding-standards": "^0.7.0",
         "composer/composer": "^2.0",
+        "cweagans/composer-patches": "^1.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "ergebnis/composer-normalize": "^2.0.0",
         "hassankhan/config": "^2.1",
@@ -36,7 +37,7 @@
         "php-coveralls/php-coveralls": "^2.2",
         "php-parallel-lint/php-console-highlighter": "^0.5.0",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "phploc/phploc": "^7.0",
+        "phploc/phploc": "7.0.2",
         "phpmd/phpmd": "^2.6",
         "stecman/symfony-console-completion": "^0.10.1",
         "symfony/config": "^4.1",
@@ -81,6 +82,11 @@
                 "vendor/bin/phpcs --cache=var/cache/phpcs.json"
             ],
             "pre-push": "vendor/bin/phpcs"
+        },
+        "patches": {
+            "phploc/phploc": [
+                "https://patch-diff.githubusercontent.com/raw/sebastianbergmann/phploc/pull/227.patch"
+            ]
         },
         "phpcodesniffer-search-depth": 4
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a013869795059377f1c0d4cffe9a312",
+    "content-hash": "ed7e62cacb41ae63e04e80cc348acc52",
     "packages": [
         {
             "name": "acquia/coding-standards",
@@ -717,6 +717,54 @@
                 }
             ],
             "time": "2021-03-25T17:01:18+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "9888dcc74993c030b75f3dd548bb5e20cdbd740c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/9888dcc74993c030b75f3dd548bb5e20cdbd740c",
+                "reference": "9888dcc74993c030b75f3dd548bb5e20cdbd740c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.1"
+            },
+            "time": "2021-06-08T15:12:46+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
Static analysis is failing on project templates and coding-standards-php following the upgrade of phploc in #163 

This is because phploc introduced a hidden breaking change in how it handles projects with no code to scan (such as project templates): https://github.com/sebastianbergmann/phploc/issues/226

This works around the issue by pinning and patching phploc until we hear from the maintainer about whether this was an intentional change. You can see it working on the project template: https://github.com/acquia/drupal-recommended-project/pull/36