### PR TITLE
Restrict media_acquiadam versions

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -209,7 +209,14 @@ drupal/lightning_workflow:
 
 drupal/mautic: []
 
-drupal/media_acquiadam: []
+drupal/media_acquiadam:
+  core_matrix:
+    8.9.x:
+      version: 1.x
+      version_dev: 1.x-dev
+    '*':
+      version: 2.x
+      version_dev: 2.x-dev
 
 drupal/mysql56:
   type: library


### PR DESCRIPTION
Drupal changed a member of core/tests/Drupal/KernelTests/Core/Entity/EntityKernelTestBase.php from public to protected access in D9. Thus a test case extending that base cannot be compatible with both versions at once.

In the case of media_acquiadam, the 2.x branch (recently released) is only compatible with the D9 definition.