### PR TITLE
Code coverage support for non-module packages

### DIFF
--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -66,6 +66,7 @@ class PhpUnitTask extends TestFrameworkBase {
     $this->ensureSimpleTestDirectory();
     $this->setSimpletestSettings();
     $this->setTestSuite();
+    $this->setCoverageFilter();
     $this->enableDrupalTestTraits();
     $this->disableSymfonyDeprecationsHelper();
     $this->setMinkDriverArguments();
@@ -106,6 +107,20 @@ class PhpUnitTask extends TestFrameworkBase {
     $this->xpath->query('//phpunit/testsuites')
       ->item(0)
       ->appendChild($testsuite);
+  }
+
+  /**
+   * Sets coverage filter in phpunit.xml.
+   *
+   * Drupal's phpunit.xml sets a whitelist for files report via clover.xml, and
+   * this whitelist only supports Drupal modules. ORCA must support non-Drupal
+   * packages as well.
+   */
+  private function setCoverageFilter(): void {
+    $directory = $this->doc->createElement('directory', $this->getPath());
+    $this->xpath->query('//phpunit/filter/whitelist')
+      ->item(0)
+      ->appendChild($directory);
   }
 
   /**

--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -118,9 +118,15 @@ class PhpUnitTask extends TestFrameworkBase {
    */
   private function setCoverageFilter(): void {
     $directory = $this->doc->createElement('directory', $this->getPath());
+    $exclude = $this->doc->createElement('exclude');
+    $exclude_directory = $this->doc->createElement('directory', "{$this->getPath()}/tests");
+    $exclude->appendChild($exclude_directory);
     $this->xpath->query('//phpunit/filter/whitelist')
       ->item(0)
       ->appendChild($directory);
+    $this->xpath->query('//phpunit/filter/whitelist')
+      ->item(0)
+      ->appendChild($exclude);
   }
 
   /**

--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -110,21 +110,41 @@ class PhpUnitTask extends TestFrameworkBase {
   }
 
   /**
-   * Sets coverage filter in phpunit.xml.
+   * Sets code coverage filters to support non-Drupal module SUTs.
    *
-   * Drupal's phpunit.xml sets a whitelist for files report via clover.xml, and
-   * this whitelist only supports Drupal modules. ORCA must support non-Drupal
-   * packages as well.
+   * Drupal core's phpunit.xml.dist sets a code coverage whitelist with test
+   * files exclusion for Drupal modules, but it does not support themes,
+   * profiles, or non-Drupal packages. Since ORCA must report test coverage for
+   * all these, it must manually add the appropriate directories for the SUT.
+   * The resulting additions look like the following:
+   *
+   * ```xml
+   * <phpunit>
+   *   <filter>
+   *     <whitelist>
+   *       <directory>/var/www/docroot/modules/contrib/example</directory>
+   *       <exclude>
+   *         <directory>/var/www/docroot/modules/contrib/example/tests</directory>
+   *       </exclude>
+   *     </whitelist>
+   *   </filter>
+   * </phpunit>
+   * ```
    */
   private function setCoverageFilter(): void {
-    $directory = $this->doc->createElement('directory', $this->getPath());
-    $exclude = $this->doc->createElement('exclude');
-    $exclude_directory = $this->doc->createElement('directory', "{$this->getPath()}/tests");
+    $directory = $this->doc
+      ->createElement('directory', $this->getPath());
+    $exclude = $this->doc
+      ->createElement('exclude');
+    $exclude_directory = $this->doc
+      ->createElement('directory', "{$this->getPath()}/tests");
     $exclude->appendChild($exclude_directory);
-    $this->xpath->query('//phpunit/filter/whitelist')
+    $this->xpath
+      ->query('//phpunit/filter/whitelist')
       ->item(0)
       ->appendChild($directory);
-    $this->xpath->query('//phpunit/filter/whitelist')
+    $this->xpath
+      ->query('//phpunit/filter/whitelist')
       ->item(0)
       ->appendChild($exclude);
   }


### PR DESCRIPTION
Code coverage reporting is currently broken for ORCA packages that are not Drupal modules (BLT, Drupal Environment Detector, etc), because Drupal core's phpunit.xml excludes non-modules from coverage reporting.

You can see this working at https://github.com/acquia/blt/pull/4420