### PR TITLE
Bump PHP versions from 7.3 to 7.4

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -59,14 +59,14 @@ jobs:
           # - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
           # - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
           # - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-        php-version: [ "7.3" ]
+        php-version: [ "7.4" ]
         include:
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.0"
 
           - orca-job: ""
             orca-live-test: "TRUE"
-            php-version: "7.3"
+            php-version: "7.4"
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: php
 
 os: [ linux ]
-dist: bionic
+dist: focal
 
 version: ~> 1.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: bionic
 
 version: ~> 1.0
 
-php: "7.3"
+php: "7.4"
 
 addons:
   chrome: stable

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -4,7 +4,7 @@ version: 1.2.0
 services:
   - mysql
   - php:
-      version: 7.3
+      version: 7.4
 
 events:
   build:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ See also [Continuous integration](understanding-orca.md#continuous-integration).
 
 ORCA can also be installed and run locally for testing and development. Follow these steps to set it up:
 
-1. Ensure you have PHP 7.2 or later (PHP 7.3 or later is recommended) with at least 256 MB of memory allocated to it and [Composer](https://getcomposer.org) installed.
+1. Ensure you have PHP 7.4 or later with at least 256 MB of memory allocated to it and [Composer](https://getcomposer.org) installed.
 
 1. Choose a directory to contain your package(s), e.g.:
 

--- a/example/.github/workflows/orca.yml
+++ b/example/.github/workflows/orca.yml
@@ -124,7 +124,7 @@ jobs:
         # The lowest version of PHP supported by all of Drupal, Acquia, and ORCA itself.
         # @see https://www.drupal.org/docs/8/system-requirements/php-requirements
         # @see https://docs.acquia.com/acquia-cloud/arch/tech-platform/
-        php-version: [ "7.3" ]
+        php-version: [ "7.4" ]
         coveralls-enable: [ "FALSE" ]
         # When manually specifying a job to include, empty parameter values (such as for orca-job and php-version) may
         # result in undefined behavior. Make sure to set each parameter explicitly.
@@ -148,7 +148,7 @@ jobs:
 
           # ORCA only executes when ORCA_JOB is set. Leave ORCA_JOB unset to execute custom jobs.
           # See ./bin/ci/example.sh for details.
-          # - php-version: "7.3"
+          # - php-version: "7.4"
     steps:
       - uses: actions/checkout@v2
 

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -25,7 +25,7 @@
 language: php
 
 os: linux
-dist: bionic
+dist: focal
 
 # Activate build config validation.
 # @see https://docs.travis-ci.com/user/build-config-validation

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -34,7 +34,7 @@ version: ~> 1.0
 # The lowest version of PHP supported by all of Drupal, Acquia, and ORCA itself.
 # @see https://www.drupal.org/docs/8/system-requirements/php-requirements
 # @see https://docs.acquia.com/acquia-cloud/arch/tech-platform/
-php: "7.3"
+php: "7.4"
 
 addons:
   # Chrome is used via ChromeDriver for web testing and browser automation.


### PR DESCRIPTION
Per https://www.php.net/supported-versions.php, security support for PHP 7.3 is ending December 6. This pull request updates ORCA to use PHP 7.4 in its CI templates and documentation.