### PR TITLE
Protect against missing includes in example code

### DIFF
--- a/example/bin/ci/example.sh
+++ b/example/bin/ci/example.sh
@@ -21,7 +21,7 @@
 cd "$(dirname "$0")" || exit 1
 
 # Reuse ORCA's own includes for its $PATH additions and environment variables.
-source ../../../orca/bin/ci/_includes.sh
+source ../../../orca/bin/ci/_includes.sh || exit
 
 # ORCA provides numerous general purpose environment variables you can use.
 echo "The SUT is cloned at $CI_WORKSPACE"

--- a/example/bin/ci/example.sh
+++ b/example/bin/ci/example.sh
@@ -21,7 +21,7 @@
 cd "$(dirname "$0")" || exit 1
 
 # Reuse ORCA's own includes for its $PATH additions and environment variables.
-source ../../../orca/bin/ci/_includes.sh || exit
+source ../../../orca/bin/ci/_includes.sh || exit 1
 
 # ORCA provides numerous general purpose environment variables you can use.
 echo "The SUT is cloned at $CI_WORKSPACE"


### PR DESCRIPTION
In our example module, if the path to the ORCA include is not correct an error will be generated but tests will not necessarily fail.