### PR TITLE
Jobs incorrectly allowed to fail

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -124,7 +124,7 @@ allowed_failures=(
   "LOOSE_DEPRECATED_CODE_SCAN"
   "ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV"
 )
-if [[ " ${allowed_failures[*]} " =~ ${ORCA_JOB} && ! $TRAVIS ]]; then
+if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " && ! $TRAVIS ]]; then
   set +e
   notice "This job is allowed to fail and will report as passing regardless of outcome."
 fi

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -120,7 +120,7 @@ allowed_failures=(
   "INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV"
   "LOOSE_DEPRECATED_CODE_SCAN"
   "ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV"
-  # These jobs temporarily allowed to fail
+  # NEXT_MINOR jobs temporarily allowed to fail
   # @see https://www.drupal.org/project/acquia_cms/issues/3248967
   "INTEGRATED_TEST_ON_NEXT_MINOR"
   "ISOLATED_TEST_ON_NEXT_MINOR"

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -114,15 +114,16 @@ alias drush='drush -r "$ORCA_FIXTURE_DIR"'
 # depending on whether the job is allowed to fail.
 
 allowed_failures=(
-  # INTEGRATED_TEST_ON_NEXT_MINOR is temporarily allowed to fail
-  # @see https://www.drupal.org/project/acquia_cms/issues/3248967
-  "INTEGRATED_TEST_ON_NEXT_MINOR"
   "INTEGRATED_TEST_ON_NEXT_MINOR_DEV"
   "DEPRECATED_CODE_SCAN_W_CONTRIB"
   "ISOLATED_TEST_ON_NEXT_MINOR_DEV"
   "INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV"
   "LOOSE_DEPRECATED_CODE_SCAN"
   "ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV"
+  # These jobs temporarily allowed to fail
+  # @see https://www.drupal.org/project/acquia_cms/issues/3248967
+  "INTEGRATED_TEST_ON_NEXT_MINOR"
+  "ISOLATED_TEST_ON_NEXT_MINOR"
 )
 if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " && ! $TRAVIS ]]; then
   set +e


### PR DESCRIPTION
This is causing custom jobs to never report failures in GitHub Actions. It's also causing some standard ORCA jobs to not report failures. The problem is that the Bash regex returns partial matches. For instance, ORCA_JOB="ISOLATED_TEST_ON_NEXT_MINOR" and ORCA_JOB="" both match on ISOLATED_TEST_ON_NEXT_MINOR_DEV, which means they end up being allowed to fail.

The fix is to match jobs as a string literal rather than regex. We also _should_ allow ISOLATED_TEST_ON_NEXT_MINOR to fail explicitly and temporarily, as we do for other NEXT_MINOR jobs.

You can see this patch applied at https://github.com/acquia/drupal-recommended-project/pull/49
- Custom jobs incorrectly allowed to fail (without patch): https://github.com/acquia/drupal-recommended-project/runs/4384056682?check_suite_focus=true#step:6:10
- Custom jobs not allowed to fail (with patch): https://github.com/acquia/drupal-recommended-project/runs/4384302487?check_suite_focus=true