### PR TITLE
Don't require Acquia CMS in D8

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -49,7 +49,12 @@
 
 acquia/acquia_cms:
   type: drupal-profile
-  version_dev: dev-develop
+  core_matrix:
+    '>=9.0.0':
+      version_dev: dev-develop
+    '8.9.x':
+      version: ~
+      version_dev: ~
 
 drupal/acquia_connector:
   version: 3.x


### PR DESCRIPTION
Latest LTS jobs are failing because ORCA tries to require Acquia CMS in D8. You can see this PR fixes the problem in an actual project: https://github.com/acquia/drupal-environment-detector/actions/runs/1593035947

This wasn't caught because ORCA's internal tests override package.yml to only require drupal/example.