### PR TITLE
ORCA-301: There is no LTS

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -114,7 +114,6 @@ alias drush='drush -r "$ORCA_FIXTURE_DIR"'
 # depending on whether the job is allowed to fail.
 
 allowed_failures=(
-  "INTEGRATED_TEST_ON_LATEST_LTS"
   "INTEGRATED_TEST_ON_NEXT_MINOR_DEV"
   "DEPRECATED_CODE_SCAN_W_CONTRIB"
   "ISOLATED_TEST_ON_NEXT_MINOR_DEV"

--- a/src/Domain/Ci/Job/Helper/RedundantJobChecker.php
+++ b/src/Domain/Ci/Job/Helper/RedundantJobChecker.php
@@ -4,6 +4,7 @@ namespace Acquia\Orca\Domain\Ci\Job\Helper;
 
 use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
 use Acquia\Orca\Enum\CiJobEnum;
+use Acquia\Orca\Exception\OrcaVersionNotFoundException;
 
 /**
  * Determines whether essentially redundant jobs exist.
@@ -85,8 +86,14 @@ class RedundantJobChecker {
         ->getDrupalCoreVersion(),
     ];
     foreach ($ci_jobs as $key => $ci_job) {
-      /* @phan-suppress-next-line PhanTypeMismatchArgumentNullable */
-      $job = $this->drupalCoreVersionResolver->resolvePredefined($ci_job);
+      try {
+        /* @phan-suppress-next-line PhanTypeMismatchArgumentNullable */
+        $job = $this->drupalCoreVersionResolver->resolvePredefined($ci_job);
+      }
+      catch (OrcaVersionNotFoundException $e) {
+        // Some versions may not exist, such as LTS. Ignore these.
+        continue;
+      }
       $ci_jobs[$key] = $job;
     }
     return $ci_jobs;

--- a/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
@@ -2,10 +2,12 @@
 
 namespace Acquia\Orca\Domain\Ci\Job;
 
+use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
 use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Options\CiRunOptions;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The integrated test on latest LTS Drupal core version CI job.
@@ -13,11 +15,25 @@ use Acquia\Orca\Options\CiRunOptions;
 class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
 
   /**
+   * The Drupal core version resolver.
+   *
+   * @var \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver
+   */
+  private $drupalCoreVersionResolver;
+
+  /**
    * The ENV facade.
    *
    * @var \Acquia\Orca\Helper\EnvFacade
    */
   private $envFacade;
+
+  /**
+   * The output decorator.
+   *
+   * @var \Symfony\Component\Console\Output\OutputInterface
+   */
+  private $output;
 
   /**
    * The process runner.
@@ -29,13 +45,19 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
   /**
    * Constructs an instance.
    *
+   * @param \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver $drupal_core_version_resolver
+   *   The Drupal core version resolver.
    * @param \Acquia\Orca\Helper\EnvFacade $env_facade
    *   The ENV facade.
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *   The output decorator.
    * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
    *   The process runner.
    */
-  public function __construct(EnvFacade $env_facade, ProcessRunner $process_runner) {
+  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver, EnvFacade $env_facade, OutputInterface $output, ProcessRunner $process_runner) {
+    $this->drupalCoreVersionResolver = $drupal_core_version_resolver;
     $this->envFacade = $env_facade;
+    $this->output = $output;
     $this->processRunner = $process_runner;
   }
 
@@ -44,6 +66,14 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
    */
   protected function jobName(): CiJobEnum {
     return CiJobEnum::INTEGRATED_TEST_ON_LATEST_LTS();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function exitEarly(): bool {
+    // An LTS does not always exist.
+    return !$this->matchingCoreVersionExists($this->drupalCoreVersionResolver, $this->output);
   }
 
   /**

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -228,6 +228,7 @@ class DrupalCoreVersionResolver {
       $message = 'No Drupal core version satisfies the given constraints: version=9, stability=stable';
       throw new OrcaVersionNotFoundException($message);
     }
+    // @todo do not assume that a branch is supported just because it's stable.
     $this->latestLts = $this->resolveArbitrary("<{$current_major}", 'stable');
 
     return $this->latestLts;

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -212,6 +212,8 @@ class DrupalCoreVersionResolver {
    *
    * @return string
    *   The semver version string, e.g., 8.9.7.
+   *
+   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
    */
   private function findLatestLts(): string {
     if ($this->latestLts) {
@@ -220,6 +222,12 @@ class DrupalCoreVersionResolver {
 
     $parts = explode('.', $this->findCurrent());
     $current_major = array_shift($parts);
+    // Drupal 8 is still marked as supported in the API even though it's EOL.
+    // @todo remove this block once D8 is EOL in the updates API.
+    if ($current_major === '9') {
+      $message = 'No Drupal core version satisfies the given constraints: version=9, stability=stable';
+      throw new OrcaVersionNotFoundException($message);
+    }
     $this->latestLts = $this->resolveArbitrary("<{$current_major}", 'stable');
 
     return $this->latestLts;

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -225,10 +225,10 @@ class DrupalCoreVersionResolver {
     // Drupal 8 is still marked as supported in the API even though it's EOL.
     // @todo remove this block once D8 is EOL in the updates API.
     if ($current_major === '9') {
-      $message = 'No Drupal core version satisfies the given constraints: version=9, stability=stable';
+      $message = 'No Drupal core version satisfies the given constraints: version=<9, stability=stable';
       throw new OrcaVersionNotFoundException($message);
     }
-    // @todo do not assume that a branch is supported just because it's stable.
+    // @todo Do not assume that a branch is supported just because it's stable.
     $this->latestLts = $this->resolveArbitrary("<{$current_major}", 'stable');
 
     return $this->latestLts;

--- a/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
+++ b/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
@@ -66,7 +66,7 @@ class DrupalDotOrgApiClient {
     $supported_branches = $config->get('supported_branches');
     $parts = explode(',', $supported_branches);
     // Drupal 8 is still marked as supported in the API even though it's EOL.
-    // @todo remove this block once D8 is EOL in the updates API.
+    // @todo Remove this block once D8 is EOL in the updates API.
     if ($parts[0] === '8.9.') {
       array_shift($parts);
     }

--- a/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
+++ b/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
@@ -65,6 +65,11 @@ class DrupalDotOrgApiClient {
     $config = new Config($xml, new Xml(), TRUE);
     $supported_branches = $config->get('supported_branches');
     $parts = explode(',', $supported_branches);
+    // Drupal 8 is still marked as supported in the API even though it's EOL.
+    // @todo remove this block once D8 is EOL in the updates API.
+    if ($parts[0] === '8.9.') {
+      unset($parts[0]);
+    }
     $this->oldestSupportedDrupalCoreBranch = $parts[0] . 'x';
     return $this->oldestSupportedDrupalCoreBranch;
   }

--- a/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
+++ b/src/Domain/Composer/Version/DrupalDotOrgApiClient.php
@@ -68,7 +68,7 @@ class DrupalDotOrgApiClient {
     // Drupal 8 is still marked as supported in the API even though it's EOL.
     // @todo remove this block once D8 is EOL in the updates API.
     if ($parts[0] === '8.9.') {
-      unset($parts[0]);
+      array_shift($parts);
     }
     $this->oldestSupportedDrupalCoreBranch = $parts[0] . 'x';
     return $this->oldestSupportedDrupalCoreBranch;

--- a/tests/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJobTest.php
+++ b/tests/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJobTest.php
@@ -4,10 +4,12 @@ namespace Acquia\Orca\Tests\Domain\Ci\Job;
 
 use Acquia\Orca\Domain\Ci\Job\AbstractCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob;
+use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
 use Acquia\Orca\Enum\DrupalCoreVersionEnum;
 use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Tests\Domain\Ci\Job\_Helper\CiJobTestBase;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @property \Acquia\Orca\Helper\EnvFacade|\Prophecy\Prophecy\ObjectProphecy $envFacade
@@ -15,15 +17,19 @@ use Acquia\Orca\Tests\Domain\Ci\Job\_Helper\CiJobTestBase;
 class IntegratedTestOnLatestLtsCiJobTest extends CiJobTestBase {
 
   public function setUp(): void {
+    $this->drupalCoreVersionResolver = $this->prophesize(DrupalCoreVersionResolver::class);
     $this->envFacade = $this->prophesize(EnvFacade::class);
+    $this->output = $this->prophesize(OutputInterface::class);
     $this->processRunner = $this->prophesize(ProcessRunner::class);
     parent::setUp();
   }
 
   protected function createJob(): AbstractCiJob {
+    $drupal_core_version_resolver = $this->drupalCoreVersionResolver->reveal();
     $env_facade = $this->envFacade->reveal();
+    $output = $this->output->reveal();
     $process_runner = $this->processRunner->reveal();
-    return new IntegratedTestOnLatestLtsCiJob($env_facade, $process_runner);
+    return new IntegratedTestOnLatestLtsCiJob($drupal_core_version_resolver, $env_facade, $output, $process_runner);
   }
 
   public function testBasicConfiguration(): void {

--- a/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
+++ b/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
@@ -123,7 +123,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
   public function testResolvePredefinedAcceptsAllVersions($version): void {
     $this->package
       ->getPrettyVersion()
-      ->willReturn('9.1.0')
+      ->willReturn('10.1.0')
       ->shouldBeCalled();
     $resolver = $this->createDrupalCoreVersionResolver();
 
@@ -158,10 +158,10 @@ class DrupalCoreVersionResolverTest extends TestCase {
   public function testResolvePredefinedLatestLts(): void {
     $this->package
       ->getPrettyVersion()
-      ->willReturn('9.1.0', '8.9.7')
+      ->willReturn('10.1.0', '9.9.7')
       ->shouldBeCalledTimes(2);
     $this->selector
-      ->findBestCandidate('drupal/core', '<9', 'stable')
+      ->findBestCandidate('drupal/core', '<10', 'stable')
       ->willReturn($this->package->reveal())
       ->shouldBeCalledOnce();
     $this->expectGetCurrentToBeCalledOnce();
@@ -171,7 +171,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
     // Call again to test value caching.
     $resolver->resolvePredefined(DrupalCoreVersionEnum::LATEST_LTS());
 
-    self::assertSame('8.9.7', $actual);
+    self::assertSame('9.9.7', $actual);
   }
 
   public function testResolvePredefinedPreviousMinor(): void {


### PR DESCRIPTION
The version resolver should reflect the fact that an LTS may not always exist (such as now that D8 is EOL and D9 does not have a final minor release).

The version resolver and the d.o API client also need to hardcode the fact that D8 is EOL, given that the Drupal updates API incorrectly marks D8 as still supported.