### PR TITLE
Trust Composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,13 @@
         "phpunit/phpunit": "^9"
     },
     "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "ergebnis/composer-normalize": true,
+            "lanfest/binary-chromedriver": true,
+            "webdriver-binary/binary-chromedriver": true
+        },
         "discard-changes": true,
         "preferred-install": {
             "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -2010,9 +2010,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -8737,5 +8734,5 @@
         "ext-sqlite3": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
[Composer 2.2 requires plugins to be explicitly trusted](https://blog.packagist.com/composer-2-2/).

Without the `allow-plugins` config, users will be prompted to trust the plugins every time they run `composer install` using Composer 2.2+, and non-interactive installs (i.e. in CI) may fail completely.