### PR TITLE
ORCA-310 Support absolute paths.

### DIFF
--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -173,13 +173,7 @@ class PackageManager {
   private function initializePackages(FixturePathHandler $fixture_path_handler, string $packages_config, ?string $packages_config_alter): void {
     $data = $this->parseYamlFile($this->orca->getPath($packages_config));
     if ($packages_config_alter) {
-      // Check if given an absolute path, else assume relative path.
-      if (file_exists($packages_config_alter)) {
-        $alter_path = $packages_config_alter;
-      }
-      else {
-        $alter_path = $this->orca->getPath($packages_config_alter);
-      }
+      $alter_path = $this->orca->getPath($packages_config_alter);
       $this->alterData = $this->parseYamlFile($alter_path);
       $data = array_merge($data, $this->alterData);
     }

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -173,7 +173,13 @@ class PackageManager {
   private function initializePackages(FixturePathHandler $fixture_path_handler, string $packages_config, ?string $packages_config_alter): void {
     $data = $this->parseYamlFile($this->orca->getPath($packages_config));
     if ($packages_config_alter) {
-      $alter_path = $this->orca->getPath($packages_config_alter);
+      // Check if given an absolute path, else assume relative path.
+      if (file_exists($packages_config_alter)) {
+        $alter_path = $packages_config_alter;
+      }
+      else {
+        $alter_path = $this->orca->getPath($packages_config_alter);
+      }
       $this->alterData = $this->parseYamlFile($alter_path);
       $data = array_merge($data, $this->alterData);
     }

--- a/src/Helper/Filesystem/AbstractPathHandler.php
+++ b/src/Helper/Filesystem/AbstractPathHandler.php
@@ -60,23 +60,35 @@ abstract class AbstractPathHandler {
    *   The base path with sub-path appended if provided.
    */
   public function getPath(?string $sub_path = NULL): string {
-    $path = $this->basePath;
-
-    // Append optional sub-path.
-    if ($sub_path) {
-      $path .= "/{$sub_path}";
+    if (!$sub_path) {
+      return $this->normalizePath($this->basePath);
     }
+    $path = $this->normalizePath($sub_path);
+    // If the directory does not exist, prepend base path for relative paths.
+    if (!is_dir($sub_path)) {
+      $path = "{$this->basePath}/{$sub_path}";
+    }
+    return $this->normalizePath($path);
+  }
 
-    // Approximate realpath() without requiring the path parts to exist yet.
-    // @see https://stackoverflow.com/a/14354948/895083
+  /**
+   * Approximate realpath() without requiring the path parts to exist yet.
+   *
+   * @param string $path
+   *   The path.
+   *
+   * @return string
+   *   The normalized path.
+   *
+   * @see https://stackoverflow.com/a/14354948/895083
+   */
+  private function normalizePath(string $path): string {
     $patterns = ['~/{2,}~', '~/(\./)+~', '~([^/\.]+/(?R)*\.{2,}/)~', '~\.\./~'];
     $replacements = ['/', '/', '', ''];
     $path = preg_replace($patterns, $replacements, $path);
 
     // Remove trailing slashes.
-    $path = rtrim($path, '/');
-
-    return $path;
+    return rtrim($path, '/');
   }
 
 }

--- a/src/Helper/Filesystem/AbstractPathHandler.php
+++ b/src/Helper/Filesystem/AbstractPathHandler.php
@@ -63,9 +63,11 @@ abstract class AbstractPathHandler {
     if (!$sub_path) {
       return $this->normalizePath($this->basePath);
     }
-    $path = $this->normalizePath($sub_path);
-    // If the directory does not exist, prepend base path for relative paths.
-    if (!is_dir($sub_path)) {
+
+    if (strpos($sub_path, '/') === 0) {
+      $path = $sub_path;
+    }
+    else {
       $path = "{$this->basePath}/{$sub_path}";
     }
     return $this->normalizePath($path);


### PR DESCRIPTION
This may not be the appropriate fix, but it was the most concise.

ORCA assumes all paths are subpaths to a location in AbstractPathHelper. This has forced ORCA to work with relative paths, which can be a pain. Especially when trying to determine the relative path for a far away directory. This adds support for direct paths.

Example CONFIG_ALTER file

```
drupal/mymodule:
  url: /Users/matt.glaman/Sites/drupal-dev-arena/web/modules/custom/mymodule
  type: drupal-module
```

Otherwise I'd need to calculate the `../../` relative paths to my `/Users/matt.glaman/Sites/drupal-dev-arena` from where ORCA resides. This also helps in CI.
