### PR TITLE
Temporarily remove drupal/acquia_search from packages

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -72,9 +72,10 @@ drupal/acsf: []
 drupal/acsf_sso:
   enable: false
 
-drupal/acquia_search:
-  version: 3.x
-  version_dev: 3.x-dev
+# @todo Temporarily remove drupal/acquia_search due to conflicts with drupal/acquia_cms.
+#drupal/acquia_search:
+#  version: 3.x
+#  version_dev: 3.x-dev
 
 acquia/blt:
   type: composer-plugin


### PR DESCRIPTION
The `drupal/acquia_search` module is currently causing `INTEGRATED_TEST_ON_CURRENT` jobs to fail with errors like the below. This pull request removes it from the active packages list until the problem can be solved.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires drupal/acquia_search 3.1.0-beta1 -> satisfiable by drupal/acquia_search[3.1.0-beta1].
    - drupal/acquia_search 3.1.0-beta1 requires drupal/acquia_connector 4.x-dev -> found drupal/acquia_connector[dev-4.x, 4.x-dev (alias of dev-4.x)] but it conflicts with your root composer.json require (3.0.4).
  Problem 2
    - drupal/acquia_search 3.1.0-beta1 requires drupal/acquia_connector 4.x-dev -> found drupal/acquia_connector[dev-4.x, 4.x-dev (alias of dev-4.x)] but it conflicts with your root composer.json require (3.0.4).
    - acquia/acquia_cms v1.4.5 requires drupal/acquia_search ^3.0.3 -> satisfiable by drupal/acquia_search[3.1.0-beta1].
    - Root composer.json requires acquia/acquia_cms v1.4.5 -> satisfiable by acquia/acquia_cms[v1.4.5].
```