### PR TITLE
[internal] automatically create jira tickets

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,36 @@
+on:
+  issues:
+    types:
+      - opened
+
+name: Create new tickets in Jira
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Create new tickets in Jira
+    permissions:
+      issues: write
+    steps:
+    - name: Login
+      uses: acquia/gajira-login@server
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+    - name: Create
+      id: create
+      uses: acquia/gajira-create@server
+      with:
+        project: ORCA
+        issuetype: Task
+        summary: ${{ github.event.issue.title }}
+        description: ${{ github.event.issue.html_url }}
+        fields: '{"labels": ["grooming"]}'
+    - name: Update Github issue with Jira ticket prefix
+      run: 'gh issue edit $GH_ISSUE --title "$JIRA_ISSUE: $ISSUE_TITLE"'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_ISSUE: ${{ github.event.issue.html_url }}
+        JIRA_ISSUE: ${{ steps.create.outputs.issue }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}


### PR DESCRIPTION
This replaces the previous integration. A new Jira ticket will be created for each new GitHub issue. The GitHub title will also be amended to include the Jira title for easy cross-reference.

This can't be easily tested before merging, but I've got the same integration working on other projects. After it's merged I'll create a test issue. I'll also need to set environment secrets for you.

Note that this GitHub action provides _way_ more flexibility than the previous integration, let me know if you'd like any adjustments.