### PR TITLE
Add all-successful job

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -105,3 +105,11 @@ jobs:
           ../orca/bin/ci/after_success.sh
           ../orca/bin/ci/after_failure.sh
           ../orca/bin/ci/after_script.sh
+
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: note that all tests succeeded
+      run: echo "🎉"

--- a/example/.github/workflows/orca.yml
+++ b/example/.github/workflows/orca.yml
@@ -216,3 +216,11 @@ jobs:
       - name: After failure
         if: ${{ failure() }}
         run: ../orca/bin/ci/after_failure.sh
+
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: note that all tests succeeded
+      run: echo "🎉"


### PR DESCRIPTION
GitHub branch protection requires explicitly defining each job that must pass in order to allow merging a PR. The problem is that ORCA's jobs are defined dynamically via a matrix, meaning that to use protected branches you need to copy every single job name into the branch protection settings and constantly keep them updated as ORCA is updated.

A much better solution is to define a single "all-successful" job that only passes if all other ORCA jobs pass, and then you can configure branch protection to just require "all-successful".