### PR TITLE
ORCA-391: all-successful job doesn't catch build failures

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -112,10 +112,16 @@ jobs:
           ../orca/bin/ci/after_failure.sh
           ../orca/bin/ci/after_script.sh
 
+  # Require all checks to pass without having to enumerate them in the branch protection UI.
+  # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
   all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    if: always()
     runs-on: ubuntu-latest
     needs: [build]
     steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
     - name: All checks successful
       run: echo "🎉"

--- a/example/.github/workflows/orca.yml
+++ b/example/.github/workflows/orca.yml
@@ -220,10 +220,16 @@ jobs:
         if: ${{ failure() }}
         run: ../orca/bin/ci/after_failure.sh
 
+  # Require all checks to pass without having to enumerate them in the branch protection UI.
+  # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
   all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    if: always()
     runs-on: ubuntu-latest
     needs: [build]
     steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
     - name: All checks successful
       run: echo "🎉"


### PR DESCRIPTION
This fixes the issue by requiring that the all-successful job run always and using the re-actors action to evaluate whether required jobs passed.

You can see proof that this works here: https://github.com/acquia/cli/pull/1040

And here's an implementation in an actual ORCA project: https://github.com/acquia/blt/pull/4539