### PR TITLE
Auto-merge dependency updates

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: Merge dependency updates
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "ORCA CI"
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+    - name: "Get PR information"
+      uses: potiuk/get-workflow-origin@v1_3
+      id: source-run-info
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        sourceRunId: ${{ github.event.workflow_run.id }}
+    - run: 'gh pr merge --squash https://github.com/$GITHUB_REPOSITORY/pull/$GITHUB_PR'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PR: ${{ steps.source-run-info.outputs.pullRequestNumber }}


### PR DESCRIPTION
I see you've enabled dependabot on this repo. I find manual review of dependabot PRs to be onerous and unnecessary. If you have good test coverage and tests pass, you might as well just automatically merge the PR and save yourself a few clicks.

I use this on all of my other repos (Acquia CLI, BLT, etc), it works great! The only difference is that we use Violinist and you use Dependabot, but I think it should still work.