### PR TITLE
Extract ORCA_LIVE_TEST to its own GitHub Actions workflow

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -22,8 +22,6 @@ jobs:
       # Boolean values must be quoted, otherwise they will be converted to lower case and break ORCA scripts.
       ORCA_SUT_NAME: drupal/example
       ORCA_SUT_BRANCH: main
-#      ORCA_PACKAGES_CONFIG: example/tests/packages.yml
-#      ORCA_PACKAGES_CONFIG_ALTER: example/tests/packages_alter.yml
       ORCA_ENABLE_NIGHTWATCH: "FALSE"
       # Hardcode path since GITHUB_WORKSPACE can't be used here.
       # @see https://github.community/t/how-to-use-env-context/16975/9

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -1,0 +1,89 @@
+---
+name: ORCA CI LIVE TEST
+on:
+    push:
+        branches: [ main, develop, wip, support/**, release/**, hotfix/** ]
+        paths-ignore:
+            - .idea/**
+            - docs/**
+    pull_request:
+        branches: [ develop ]
+        paths-ignore:
+            - .idea/**
+            - docs/**
+    schedule:
+        # Daily at 00:00:00 UTC.
+        # @see https://crontab.cronhub.io/
+        -   cron: "0 0 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # Boolean values must be quoted, otherwise they will be converted to lower case and break ORCA scripts.
+      ORCA_SUT_NAME: drupal/example
+      ORCA_SUT_BRANCH: main
+#      ORCA_PACKAGES_CONFIG: example/tests/packages.yml
+#      ORCA_PACKAGES_CONFIG_ALTER: example/tests/packages_alter.yml
+      ORCA_ENABLE_NIGHTWATCH: "FALSE"
+      # Hardcode path since GITHUB_WORKSPACE can't be used here.
+      # @see https://github.community/t/how-to-use-env-context/16975/9
+      ORCA_SUT_DIR: /home/runner/work/orca/example
+      ORCA_SELF_TEST_COVERAGE_CLOVER: $HOME/build/logs/clover-self.xml
+      ORCA_LIVE_TEST: TRUE
+
+    strategy:
+      matrix:
+        orca-job:
+          - " "
+        php-version: [ "7.4" ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
+
+      - name: Before install
+        run: |
+          ../orca/bin/ci/self-test/before_install.sh
+          ../orca/bin/ci/before_install.sh
+
+      - name: Install
+        run: |
+          ../orca/bin/ci/self-test/install.sh
+          ../orca/bin/ci/install.sh
+
+      - name: Before script
+        run: ../orca/bin/ci/before_script.sh
+
+      - name: Script
+        run: |
+          ../orca/bin/ci/self-test/script.sh
+          ../orca/bin/ci/script.sh
+
+      # These two jobs need to run regardless of success or failure in ORCA's self-tests in order to exercise the code.
+      - name: After script
+        run: |
+          ../orca/bin/ci/self-test/after_success.sh
+          ../orca/bin/ci/after_success.sh
+          ../orca/bin/ci/after_failure.sh
+          ../orca/bin/ci/after_script.sh
+
+  # Require all checks to pass without having to enumerate them in the branch protection UI.
+  # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
+  all-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+    - name: All checks successful
+      run: echo "🎉"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -30,7 +30,6 @@ jobs:
       ORCA_SUT_DIR: /home/runner/work/orca/example
       ORCA_SELF_TEST_COVERAGE_CLOVER: $HOME/build/logs/clover-self.xml
       ORCA_JOB: ${{ matrix.orca-job }}
-      ORCA_LIVE_TEST: ${{ matrix.orca-live-test }}
 
     strategy:
       matrix:
@@ -76,11 +75,6 @@ jobs:
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.1"
             orca-enable-nightwatch: "TRUE"
-
-          - orca-job: ""
-            orca-live-test: "TRUE"
-            php-version: "7.4"
-            orca-enable-nightwatch: "FALSE"
 
     steps:
       - uses: actions/checkout@v2

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -129,7 +129,7 @@ allowed_failures=(
   "INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV"
   "INTEGRATED_TEST_ON_CURRENT_DEV"
 )
-if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " || "${ORCA_LIVE_TEST}" == "TRUE"  && ! $TRAVIS ]]; then
+if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " && ! $TRAVIS ]]; then
   set +e
   notice "This job is allowed to fail and will report as passing regardless of outcome."
 fi

--- a/bin/ci/self-test/_includes.sh
+++ b/bin/ci/self-test/_includes.sh
@@ -12,6 +12,8 @@
 source ../_includes.sh
 
 if [[ "$ORCA_LIVE_TEST" ]]; then
+  set +e
+  notice "This job is allowed to fail and will report as passing regardless of outcome."
   unset ORCA_PACKAGES_CONFIG
   unset ORCA_PACKAGES_CONFIG_ALTER
 fi


### PR DESCRIPTION
This reverts commit 18f4c9c5f10a6ddf943c71b3bfb5c469db863371 and creates a separate workflow for the Live Test in Github Actions