### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Some of ORCA's dependencies are outdated and actually have breaking changes that need to be addressed. It's good to keep these updated automatically.