### PR TITLE
Change precedence of PATH values for finding correct version of PHP

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -104,8 +104,8 @@ export PATH="$ORCA_FIXTURE_DIR/vendor/bin:$PATH"
 export PATH="$CI_WORKSPACE/vendor/bin:$PATH"
 # Put this last to ensure that the host's Composer is preferred.
 export PATH="$HOME/.phpenv/shims/:$PATH"
-export PATH="/usr/local/bin/:$PATH"
 export PATH="/usr/bin/:$PATH"
+export PATH="/usr/local/bin/:$PATH"
 
 # Add convenient aliases.
 alias drush='drush -r "$ORCA_FIXTURE_DIR"'

--- a/bin/ci/before_install.sh
+++ b/bin/ci/before_install.sh
@@ -75,6 +75,7 @@ if [[ "$TRAVIS" ]]; then
 fi
 
 # Display PHP information.
+which php
 php -i
 
 # Download and install ORCA libraries if necessary. This provides compatibility


### PR DESCRIPTION
Change the order of the exported PATH variable to aid in choosing the correct version of php in CI systems.