### PR TITLE
Point to appropriate version of DRP

### DIFF
--- a/src/Options/FixtureOptions.php
+++ b/src/Options/FixtureOptions.php
@@ -300,14 +300,13 @@ class FixtureOptions {
       return $this->options['project-template'];
     }
 
+    // @todo Point to latest version of DRP once 2.x for D10 stable fixtures
+    //   and "dev-master" for D10 dev fixtures.
     if ($this->coreVersionParsedMatches('^10')) {
       $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-drupal10';
     }
-    elseif ($this->coreVersionParsedMatches('^9') && $this->isDev()) {
-      $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-master';
-    }
     else {
-      $this->options['project-template'] = 'acquia/drupal-recommended-project';
+      $this->options['project-template'] = 'acquia/drupal-recommended-project:^1';
     }
 
     return $this->options['project-template'];

--- a/tests/Options/FixtureOptionsTest.php
+++ b/tests/Options/FixtureOptionsTest.php
@@ -76,7 +76,7 @@ class FixtureOptionsTest extends TestCase {
     self::assertFalse($options->symlinkAll(), 'Set/got default "symlink-all" option.');
     self::assertEquals($core, $options->getCore(), 'Set/got default "core" option.');
     self::assertEquals('orca', $options->getProfile(), 'Set/got default "profile" option.');
-    self::assertEquals('acquia/drupal-recommended-project', $options->getProjectTemplate(), 'Set/got default "project-template" option.');
+    self::assertEquals('acquia/drupal-recommended-project:^1', $options->getProjectTemplate(), 'Set/got default "project-template" option.');
     self::assertNull($options->getSut(), 'Set/got default "sut" option.');
     self::assertTrue($options->installSite(), 'Set/got default "no-site-install" option.');
     self::assertTrue($options->useSqlite(), 'Set/got default "no-sqlite" option.');


### PR DESCRIPTION
This change will prevent ORCA outages when DRP releases new latest tag for D10 and has to be merged and released before DRP's D10 release.

cc: @vishalkhode1 