### PR TITLE
Adding Drupal core nightwatch tests

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Script
         run: |
           ../orca/bin/ci/self-test/script.sh
+          unset ORCA_ENABLE_NIGHTWATCH
           ../orca/bin/ci/script.sh
 
       # These two jobs need to run regardless of success or failure in ORCA's self-tests in order to exercise the code.

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -30,6 +30,15 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
       --passWithNoTests \\
       --tag=$ORCA_SUT_MACHINE_NAME"
 
+    if [[ "$ORCA_SUT_NAME" == "drupal/example" ]]; then
+      (
+        eval "yarn test:nightwatch \\
+          --headless \\
+          --passWithNoTests \\
+          --tag=core"
+      )
+    fi
+
     kill -0 $SERVER_PID
     kill -0 $CHROMEDRIVER_PID
   )

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -30,15 +30,6 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
       --passWithNoTests \\
       --tag=$ORCA_SUT_MACHINE_NAME"
 
-    if [[ "$ORCA_SUT_NAME" == "drupal/example" ]]; then
-      (
-        eval "yarn test:nightwatch \\
-          --headless \\
-          --passWithNoTests \\
-          --tag=core"
-      )
-    fi
-
     kill -0 $SERVER_PID
     kill -0 $CHROMEDRIVER_PID
   )


### PR DESCRIPTION
We want to run Drupal Core's nightwatch tests so that we can increase the coverage of testing nightwatch in ORCA