### PR TITLE
Bump Drupal Spec Tool version for Drupal 10

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -122,7 +122,7 @@ acquia/drupal-spec-tool:
   type: behat-extension
   core_matrix:
     10.x:
-      version: ~
+      version: 6.x
       version_dev: 6.x-dev
     '*':
       version: 5.x


### PR DESCRIPTION
The new 6.x branch of the Drupal Spec Tool is Drupal 10-compatible. @secretsayan, we can discuss the implications of this for the next ORCA release.