### PR TITLE
ORCA-471: Modifications to accomodate ACMS

### DIFF
--- a/example/tests/src/FunctionalJavascript/ExampleHomeLinkTest.php
+++ b/example/tests/src/FunctionalJavascript/ExampleHomeLinkTest.php
@@ -10,7 +10,7 @@ class ExampleHomeLinkTest extends WebDriverTestBase {
 
   public function testHomePageLink(): void {
     $page = $this->getSession()->getPage();
-    $content = $page->findLink('Home');
+    $content = $page->findLink('Log in');
     $this->assertTrue($content->isVisible());
   }
 

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -266,11 +266,8 @@ class FixtureCreator {
     }
 
     // Acquia CMS uses drupal-test-traits as a dev dependency.
-    // Add only when Drupal core version is NOT 10.
     // @todo remove this via ORCA-298
-    if (!$this->options->coreVersionParsedMatches('^10')) {
-      $additions[] = 'weitzman/drupal-test-traits';
-    }
+    $additions[] = 'weitzman/drupal-test-traits';
 
     // Require additional packages.
     $prefer_source = $this->options->preferSource();


### PR DESCRIPTION
- Change Functional Javascript Tests
- Add back _weitzman/drupal-test-traits_ which was removed during D10 readiness initiative.