### PR TITLE
ORCA-503: Fix skipping incorrect job

### DIFF
--- a/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Orca\Domain\Ci\Job;
 
+use Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker;
 use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
 use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Helper\EnvFacade;
@@ -43,6 +44,13 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
   private $processRunner;
 
   /**
+   * The redundant job checker.
+   *
+   * @var \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker
+   */
+  private $redundantJobChecker;
+
+  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver $drupal_core_version_resolver
@@ -53,12 +61,19 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
    *   The output decorator.
    * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
    *   The process runner.
+   * @param \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker $redundant_job_checker
+   *   The redundant job checker.
    */
-  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver, EnvFacade $env_facade, OutputInterface $output, ProcessRunner $process_runner) {
+  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver,
+    EnvFacade $env_facade,
+  OutputInterface $output,
+  ProcessRunner $process_runner,
+    RedundantJobChecker $redundant_job_checker) {
     $this->drupalCoreVersionResolver = $drupal_core_version_resolver;
     $this->envFacade = $env_facade;
     $this->output = $output;
     $this->processRunner = $process_runner;
+    $this->redundantJobChecker = $redundant_job_checker;
   }
 
   /**
@@ -70,10 +85,13 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
 
   /**
    * {@inheritdoc}
+   *
+   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
    */
   protected function exitEarly(): bool {
     // An LTS does not always exist.
-    return !$this->matchingCoreVersionExists($this->drupalCoreVersionResolver, $this->output);
+    return !$this->matchingCoreVersionExists($this->drupalCoreVersionResolver, $this->output)
+      || $this->isRedundant($this->redundantJobChecker, $this->output);
   }
 
   /**

--- a/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJob.php
@@ -64,11 +64,13 @@ class IntegratedTestOnLatestLtsCiJob extends AbstractCiJob {
    * @param \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker $redundant_job_checker
    *   The redundant job checker.
    */
-  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver,
+  public function __construct(
+    DrupalCoreVersionResolver $drupal_core_version_resolver,
     EnvFacade $env_facade,
-  OutputInterface $output,
-  ProcessRunner $process_runner,
-    RedundantJobChecker $redundant_job_checker) {
+    OutputInterface $output,
+    ProcessRunner $process_runner,
+    RedundantJobChecker $redundant_job_checker
+  ) {
     $this->drupalCoreVersionResolver = $drupal_core_version_resolver;
     $this->envFacade = $env_facade;
     $this->output = $output;

--- a/src/Domain/Ci/Job/IntegratedTestOnPreviousMinorCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnPreviousMinorCiJob.php
@@ -2,12 +2,10 @@
 
 namespace Acquia\Orca\Domain\Ci\Job;
 
-use Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker;
 use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Options\CiRunOptions;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The integrated test on previous minor CI job.
@@ -22,13 +20,6 @@ class IntegratedTestOnPreviousMinorCiJob extends AbstractCiJob {
   private $envFacade;
 
   /**
-   * The output decorator.
-   *
-   * @var \Symfony\Component\Console\Output\OutputInterface
-   */
-  private $output;
-
-  /**
    * The process runner.
    *
    * @var \Acquia\Orca\Helper\Process\ProcessRunner
@@ -36,29 +27,16 @@ class IntegratedTestOnPreviousMinorCiJob extends AbstractCiJob {
   private $processRunner;
 
   /**
-   * The redundant job finder.
-   *
-   * @var \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker
-   */
-  private $redundantJobChecker;
-
-  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Helper\EnvFacade $env_facade
    *   The ENV facade.
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *   The output decorator.
    * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
    *   The process runner.
-   * @param \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker $redundant_job_checker
-   *   The redundant job finder.
    */
-  public function __construct(EnvFacade $env_facade, OutputInterface $output, ProcessRunner $process_runner, RedundantJobChecker $redundant_job_checker) {
+  public function __construct(EnvFacade $env_facade, ProcessRunner $process_runner) {
     $this->envFacade = $env_facade;
-    $this->output = $output;
     $this->processRunner = $process_runner;
-    $this->redundantJobChecker = $redundant_job_checker;
   }
 
   /**
@@ -66,15 +44,6 @@ class IntegratedTestOnPreviousMinorCiJob extends AbstractCiJob {
    */
   protected function jobName(): CiJobEnum {
     return CiJobEnum::INTEGRATED_TEST_ON_PREVIOUS_MINOR();
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
-   */
-  protected function exitEarly(): bool {
-    return $this->isRedundant($this->redundantJobChecker, $this->output);
   }
 
   /**

--- a/tests/Domain/Ci/Job/Helper/RedundantJobCheckerTest.php
+++ b/tests/Domain/Ci/Job/Helper/RedundantJobCheckerTest.php
@@ -91,7 +91,7 @@ class RedundantJobCheckerTest extends TestCase {
         'oldest_supported' => '8.0.0',
         'latest_lts' => '9.0.0',
         'previous_minor' => '9.0.0',
-      // previous_minor always runs.
+        // previous_minor always runs.
         'is_redundant' => FALSE,
       ],
       'All three are duplicates' => [
@@ -99,7 +99,7 @@ class RedundantJobCheckerTest extends TestCase {
         'oldest_supported' => '8.0.0',
         'latest_lts' => '8.0.0',
         'previous_minor' => '8.0.0',
-      // previous_minor always runs.
+        // previous_minor always runs.
         'is_redundant' => FALSE,
       ],
       'Inapplicable job' => [

--- a/tests/Domain/Ci/Job/Helper/RedundantJobCheckerTest.php
+++ b/tests/Domain/Ci/Job/Helper/RedundantJobCheckerTest.php
@@ -63,6 +63,13 @@ class RedundantJobCheckerTest extends TestCase {
         'oldest_supported' => '8.0.0',
         'latest_lts' => '8.0.0',
         'previous_minor' => '9.0.0',
+        'is_redundant' => FALSE,
+      ],
+      'Latest LTS duplicates Oldest supported' => [
+        'ci_job' => CiJobEnum::INTEGRATED_TEST_ON_LATEST_LTS(),
+        'oldest_supported' => '8.0.0',
+        'latest_lts' => '8.0.0',
+        'previous_minor' => '9.0.0',
         'is_redundant' => TRUE,
       ],
       'Oldest supported duplicates previous minor' => [
@@ -84,14 +91,16 @@ class RedundantJobCheckerTest extends TestCase {
         'oldest_supported' => '8.0.0',
         'latest_lts' => '9.0.0',
         'previous_minor' => '9.0.0',
-        'is_redundant' => TRUE,
+      // previous_minor always runs.
+        'is_redundant' => FALSE,
       ],
       'All three are duplicates' => [
         'ci_job' => CiJobEnum::INTEGRATED_TEST_ON_PREVIOUS_MINOR(),
         'oldest_supported' => '8.0.0',
         'latest_lts' => '8.0.0',
         'previous_minor' => '8.0.0',
-        'is_redundant' => TRUE,
+      // previous_minor always runs.
+        'is_redundant' => FALSE,
       ],
       'Inapplicable job' => [
         'ci_job' => CiJobEnum::INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER(),

--- a/tests/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJobTest.php
+++ b/tests/Domain/Ci/Job/IntegratedTestOnLatestLtsCiJobTest.php
@@ -3,16 +3,21 @@
 namespace Acquia\Orca\Tests\Domain\Ci\Job;
 
 use Acquia\Orca\Domain\Ci\Job\AbstractCiJob;
+use Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob;
 use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
+use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Enum\DrupalCoreVersionEnum;
 use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Tests\Domain\Ci\Job\_Helper\CiJobTestBase;
+use Prophecy\Argument;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @property \Acquia\Orca\Helper\EnvFacade|\Prophecy\Prophecy\ObjectProphecy $envFacade
+ *
+ * @property \Acquia\Orca\Domain\Ci\Job\Helper\RedundantJobChecker|\Prophecy\Prophecy\ObjectProphecy $redundantJobChecker
  */
 class IntegratedTestOnLatestLtsCiJobTest extends CiJobTestBase {
 
@@ -21,6 +26,10 @@ class IntegratedTestOnLatestLtsCiJobTest extends CiJobTestBase {
     $this->envFacade = $this->prophesize(EnvFacade::class);
     $this->output = $this->prophesize(OutputInterface::class);
     $this->processRunner = $this->prophesize(ProcessRunner::class);
+    $this->redundantJobChecker = $this->prophesize(RedundantJobChecker::class);
+    $this->redundantJobChecker
+      ->isRedundant(Argument::any())
+      ->willReturn(FALSE);
     parent::setUp();
   }
 
@@ -29,13 +38,16 @@ class IntegratedTestOnLatestLtsCiJobTest extends CiJobTestBase {
     $env_facade = $this->envFacade->reveal();
     $output = $this->output->reveal();
     $process_runner = $this->processRunner->reveal();
-    return new IntegratedTestOnLatestLtsCiJob($drupal_core_version_resolver, $env_facade, $output, $process_runner);
+    $redundant_job_checker = $this->redundantJobChecker->reveal();
+    return new IntegratedTestOnLatestLtsCiJob($drupal_core_version_resolver,
+      $env_facade, $output, $process_runner, $redundant_job_checker);
   }
 
   public function testBasicConfiguration(): void {
     $job = $this->createJob();
 
-    self::assertEquals(DrupalCoreVersionEnum::LATEST_LTS(), $job->getDrupalCoreVersion(), 'Declared the correct Drupal core version.');
+    self::assertEquals(DrupalCoreVersionEnum::LATEST_LTS(), $job->getDrupalCoreVersion(),
+      'Declared the correct Drupal core version.');
   }
 
   public function testInstall(): void {
@@ -51,6 +63,22 @@ class IntegratedTestOnLatestLtsCiJobTest extends CiJobTestBase {
     $job = $this->createJob();
 
     $this->runInstallPhase($job);
+  }
+
+  public function testRedundantJob(): void {
+    $this->redundantJobChecker
+      ->isRedundant(CiJobEnum::INTEGRATED_TEST_ON_LATEST_LTS())
+      ->willReturn(TRUE);
+    $this->output
+      ->writeln(Argument::any())
+      ->shouldBeCalledTimes(2);
+    $this->processRunner
+      ->runOrca(Argument::any())
+      ->shouldNotBeCalled();
+    $job = $this->createJob();
+
+    $this->runScriptPhase($job);
+    $this->runScriptPhase($job);
   }
 
   public function testInstallOverrideProfile(): void {


### PR DESCRIPTION
- Ensures exactly one job is run when multiple jobs (LATEST_LTS, OLDEST_SUPPORTED, PREVIOUS_MINOR) have same drupal core version.