### PR TITLE
Fix exceptions

### DIFF
--- a/example/tests/packages_alter.yml
+++ b/example/tests/packages_alter.yml
@@ -11,3 +11,19 @@ drupal/example:
 
 # Remove the Example Submodule: Remove module.
 drupal/example_submodule_remove: ~
+
+# Dependencies required to run ORCA's self tests.
+drush/drush:
+  is_company_package: false
+  core_matrix:
+    9.x:
+      version: 11.x
+      version_dev: 11.x
+    '*':
+      version: 12.x
+      version_dev: 12.x-dev
+
+phpspec/prophecy-phpunit:
+  is_company_package: false
+  version: 2.x
+  version_dev: 2.x

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -212,7 +212,7 @@ class GoogleApiClient {
     }
     catch (ExceptionInterface $e) {
       $this->output->comment('An error occurred accessing the auth token from Google API endpoint.\n' . $e->getMessage());
-      exit;
+      return NULL;
     }
   }
 

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -212,7 +212,7 @@ class GoogleApiClient {
     }
     catch (ExceptionInterface $e) {
       $this->output->comment('An error occurred accessing the auth token from Google API endpoint.\n' . $e->getMessage());
-      return;
+      return NULL;
     }
   }
 

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -212,7 +212,7 @@ class GoogleApiClient {
     }
     catch (ExceptionInterface $e) {
       $this->output->comment('An error occurred accessing the auth token from Google API endpoint.\n' . $e->getMessage());
-      return NULL;
+      return;
     }
   }
 


### PR DESCRIPTION
- Since ORCA's self tests do not use the `config/packages.yml` we are adding the dependencies in `example/tests/packages_alter.yml` so that they can be picked up during fixture creation.