### PR TITLE
ORCA-531: Composer exit on patch failure

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -123,6 +123,7 @@ allowed_failures=(
 )
 if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " ]]; then
   set +e
+  export ORCA_IS_ALLOWED_FAILURE="TRUE"
   notice "This job is allowed to fail and will report as passing regardless of outcome."
 fi
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -13,6 +13,7 @@ parameters:
   env(ORCA_PACKAGES_CONFIG_ALTER): ~
   env(ORCA_PHPCS_STANDARD): "AcquiaDrupalTransitional"
   env(ORCA_TELEMETRY_ENABLE): "false"
+  env(ORCA_IS_ALLOWED_FAILURE): "%env(ORCA_IS_ALLOWED_FAILURE)%"
 
 services:
 
@@ -30,6 +31,7 @@ services:
       $packages_config: "@=container.getParameter('ORCA_PACKAGES_CONFIG') === '' ? 'config/packages.yml' : parameter('ORCA_PACKAGES_CONFIG')"
       $packages_config_alter: "%env(ORCA_PACKAGES_CONFIG_ALTER)%"
       $telemetry_is_enabled: "%env(bool:ORCA_TELEMETRY_ENABLE)%"
+      $is_allowed_failure: "%env(ORCA_IS_ALLOWED_FAILURE)%"
     public: true
 
   Acquia\Orca\:

--- a/config/services.yml
+++ b/config/services.yml
@@ -31,7 +31,6 @@ services:
       $packages_config: "@=container.getParameter('ORCA_PACKAGES_CONFIG') === '' ? 'config/packages.yml' : parameter('ORCA_PACKAGES_CONFIG')"
       $packages_config_alter: "%env(ORCA_PACKAGES_CONFIG_ALTER)%"
       $telemetry_is_enabled: "%env(bool:ORCA_TELEMETRY_ENABLE)%"
-      $is_allowed_failure: "%env(ORCA_IS_ALLOWED_FAILURE)%"
     public: true
 
   Acquia\Orca\:

--- a/src/Domain/Composer/ComposerFacade.php
+++ b/src/Domain/Composer/ComposerFacade.php
@@ -262,6 +262,22 @@ class ComposerFacade {
   }
 
   /**
+   * Set config to root composer.json.
+   *
+   * @param array $config
+   *   A list of config elements to be removed, e.g., "platform".
+   */
+  public function setConfig(array $config): void {
+    if (empty($config)) {
+      throw new \InvalidArgumentException('No config provided to remove.');
+    }
+
+    $this->runComposer([
+      'config',
+    ], $config);
+  }
+
+  /**
    * Validates a composer.json.
    *
    * @param string $path

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -137,6 +137,8 @@ class FixtureCreator {
   private $fixtureCustomizer;
 
   /**
+   * The environment facade.
+   *
    * @var \Acquia\Orca\Helper\EnvFacade
    */
   private EnvFacade $env;
@@ -174,23 +176,26 @@ class FixtureCreator {
    *   The version finder.
    * @param \Acquia\Orca\Domain\Fixture\FixtureCustomizer $fixtureCustomizer
    *   The fixture customizer.
+   * @param \Acquia\Orca\Helper\EnvFacade $env
+   *   The environment facade.
    */
   public function __construct(CloudHooksInstaller $cloud_hooks_installer,
-  CodebaseCreator $codebase_creator,
+    CodebaseCreator $codebase_creator,
     ComposerFacade $composer,
-  ComposerJsonHelper $composer_json_helper,
-  DrupalSettingsHelper $drupal_settings_helper,
+    ComposerJsonHelper $composer_json_helper,
+    DrupalSettingsHelper $drupal_settings_helper,
     FixturePathHandler $fixture_path_handler,
-  FixtureInspector $fixture_inspector,
-  GitFacade $git,
+    FixtureInspector $fixture_inspector,
+    GitFacade $git,
     SiteInstaller $site_installer,
-  SymfonyStyle $output,
-  ProcessRunner $process_runner,
+    SymfonyStyle $output,
+    ProcessRunner $process_runner,
     PackageManager $package_manager,
-  SubextensionManager $subextension_manager,
-  VersionFinder $version_finder,
+    SubextensionManager $subextension_manager,
+    VersionFinder $version_finder,
     FixtureCustomizer $fixtureCustomizer,
-  EnvFacade $env) {
+    EnvFacade $env
+  ) {
     $this->cloudHooksInstaller = $cloud_hooks_installer;
     $this->codebaseCreator = $codebase_creator;
     $this->composer = $composer;
@@ -250,8 +255,7 @@ class FixtureCreator {
    * Configures composer "composer-exit-on-patch-failure" parameter.
    */
   private function configureComposerExitOnPatchFailure(): void {
-
-    if ($this->env->get('ORCA_IS_ALLOWED_FAILURE')) {
+    if (!$this->env->get('ORCA_IS_ALLOWED_FAILURE')) {
       return;
     }
 

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -268,7 +268,7 @@ class FixtureCreator {
       ]);
     }
     catch (\Exception $e) {
-      $this->output->writeln("Failed to remove Composer platform requirements.");
+      $this->output->writeln("Failed to set composer-exit-on-patch-failure.");
     }
   }
 

--- a/tests/Domain/Fixture/FixtureCreatorTest.php
+++ b/tests/Domain/Fixture/FixtureCreatorTest.php
@@ -15,6 +15,7 @@ use Acquia\Orca\Domain\Fixture\SiteInstaller;
 use Acquia\Orca\Domain\Fixture\SubextensionManager;
 use Acquia\Orca\Domain\Git\GitFacade;
 use Acquia\Orca\Domain\Package\PackageManager;
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Filesystem\FixturePathHandler;
 use Acquia\Orca\Helper\Filesystem\OrcaPathHandler;
 use Acquia\Orca\Helper\Process\ProcessRunner;
@@ -58,6 +59,7 @@ class FixtureCreatorTest extends TestCase {
   protected ProcessRunner|ObjectProphecy $processRunner;
   protected SymfonyStyle|ObjectProphecy $output;
   protected FixtureCustomizer|ObjectProphecy $customizer;
+  protected EnvFacade|ObjectProphecy $envFacade;
 
   protected function setUp(): void {
     $this->cloudHooksInstaller = $this->prophesize(CloudHooksInstaller::class);
@@ -76,6 +78,7 @@ class FixtureCreatorTest extends TestCase {
     $this->versionFinder = $this->prophesize(VersionFinder::class);
     $this->output = $this->prophesize(SymfonyStyle::class);
     $this->customizer = $this->prophesize(FixtureCustomizer::class);
+    $this->envFacade = $this->prophesize(EnvFacade::class);
   }
 
   private function createFixtureCreator(): FixtureCreator {
@@ -94,6 +97,7 @@ class FixtureCreatorTest extends TestCase {
     $subextension_manager = $this->subextensionManager->reveal();
     $version_finder = $this->versionFinder->reveal();
     $customizer = $this->customizer->reveal();
+    $env = $this->envFacade->reveal();
     return new FixtureCreator(
         $cloud_hooks_installer,
         $codebase_creator,
@@ -109,7 +113,8 @@ class FixtureCreatorTest extends TestCase {
         $package_manager,
         $subextension_manager,
         $version_finder,
-        $customizer
+        $customizer,
+        $env
     );
   }
 


### PR DESCRIPTION
Sets `composer-exit-on-patch-failure` to `false` for all the jobs which are allowed to fail.