### PR TITLE
Clean up GitHub workflows

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,0 +1,14 @@
+# This workflow attempts to automatically label pull requests by examining labels on linked issues.
+# For instance, if a PR says it "Fixes #123", and issue #123 is labeled as a Bug, this workflow will
+# automatically label the PR as a bug as well.
+name: Auto-label pull requests
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  pull-requests: write
+jobs:
+  autolabel:
+    uses: acquia/.github/.github/workflows/autolabel.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,28 +1,18 @@
-name: Merge dependency updates
+# This workflow automatically merges dependency updates provided by dependabot.
+# It will run whenever the workflow defined below passes and branch protection rules are satisfied.
+name: Auto-merge dependency updates
 on:
   workflow_run:
     types:
       - "completed"
+    # Update this to match the name of your CI workflow, which must pass before updates are merged.
     workflows:
       - "ORCA CI"
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
-  merge:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
-    steps:
-    - name: "Get PR information"
-      uses: potiuk/get-workflow-origin@v1_4
-      id: source-run-info
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        sourceRunId: ${{ github.event.workflow_run.id }}
-    - run: 'gh pr merge --squash https://github.com/$GITHUB_REPOSITORY/pull/$GITHUB_PR'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PR: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+  automerge:
+    uses: acquia/.github/.github/workflows/automerge.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,35 +1,24 @@
+# When someone opens a public GitHub issue, this workflow will create a corresponding
+# Jira ticket and update the issue title to reference the Jira ticket number.
+# When someone closes a public GitHub issue, this workflow will comment on the linked
+# Jira ticket indicating that the issue was closed.
+# Your Jira project key must match the repository name.
+name: Sync GitHub issues to Jira
 on:
   issues:
     types:
       - opened
-
-name: Create new tickets in Jira
-
+      - closed
+permissions:
+  issues: write
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Create new tickets in Jira
-    permissions:
-      issues: write
-    steps:
-    - name: Login
-      uses: acquia/gajira-login@bearer
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-    - name: Create
-      id: create
-      uses: acquia/gajira-create@bearer
-      with:
-        project: ORCA
-        issuetype: Task
-        summary: ${{ github.event.issue.title }}
-        description: ${{ github.event.issue.html_url }}
-        fields: '{"labels": ["grooming"]}'
-    - name: Update Github issue with Jira ticket prefix
-      run: 'gh issue edit $GH_ISSUE --title "$JIRA_ISSUE: $ISSUE_TITLE"'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_ISSUE: ${{ github.event.issue.html_url }}
-        JIRA_ISSUE: ${{ steps.create.outputs.issue }}
-        ISSUE_TITLE: ${{ github.event.issue.title }}
+  jira:
+    uses: acquia/.github/.github/workflows/jira.yml@main
+    # Set the JIRA* secrets in your repository settings. You will need to create an API
+    # token from your Jira user profile.
+    secrets:
+      jira-base-url: ${{ secrets.JIRA_BASE_URL }}
+      jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      issue_label: grooming


### PR DESCRIPTION
I exported these Actions workflows from Acquia CLI, where they were originally developed, to the acquia/.github repo, where they can be easily reused by any public Acquia repo.

Importing those reusable workflows rather than copying them verbatim in every downstream repo is much more maintainable.