### PR TITLE
Remove JIRA_BASE_URL

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -17,7 +17,6 @@ jobs:
     # Set the JIRA* secrets in your repository settings. You will need to create an API
     # token from your Jira user profile.
     secrets:
-      jira-base-url: ${{ secrets.JIRA_BASE_URL }}
       jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
JIRA_BASE_URL is now provided as an organization variable.

Please merge this PR, then remove JIRA_BASE_URL from the repo settings (admin access required, let me know if you need help): https://github.com/acquia/orca/settings/secrets/actions