### PR TITLE
ORCA-568: Ignore push builds for dependabot

### DIFF
--- a/example/.github/workflows/orca.yml
+++ b/example/.github/workflows/orca.yml
@@ -24,7 +24,10 @@
 ---
 name: ORCA CI
 on:
-  push: ~
+  push:
+    # Prevent duplicate jobs on Dependabot PRs that interfere with automerge.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request: ~
   schedule:
     # Daily at 00:00:00 UTC.


### PR DESCRIPTION
Currently when `dependabot` pushes a commit in a pull request it triggers two jobs :
1. Firstly, the job for the `pull request changes` happening due to this commit.
2. Secondly, the job for the `push event` in the pull request branch created in origin by `dependabot`

This PR intends to eliminate the second one i.e. triggering of a job due to a `push event` in a branch created by `dependabot` as it is redundant. 