### PR TITLE
ORCA-561: Domo Improvements

### DIFF
--- a/.idea/orca.iml
+++ b/.idea/orca.iml
@@ -2,9 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Acquia\Orca\Tests\" />
-      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Acquia\Orca\" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/var" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/justinrainbow/json-schema" />

--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -6,6 +6,7 @@
         <cache>
           <versions>
             <info id="Local" version="9.5.10" />
+            <info id="Local/Users/sayan.goswami/Workspace/Code/ACQUIAORCA/orca/vendor/autoload.php" version="9.6.9" />
           </versions>
         </cache>
       </tool>

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -122,7 +122,6 @@ allowed_failures=(
   "INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER"
 )
 if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " ]]; then
-#  set +e
   export ORCA_IS_ALLOWED_FAILURE="TRUE"
   notice "This job is allowed to fail and will report as passing regardless of outcome."
 fi

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -122,10 +122,18 @@ allowed_failures=(
   "INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER"
 )
 if [[ " ${allowed_failures[*]} " =~ " ${ORCA_JOB} " ]]; then
-  set +e
+#  set +e
   export ORCA_IS_ALLOWED_FAILURE="TRUE"
   notice "This job is allowed to fail and will report as passing regardless of outcome."
 fi
+
+function shutdown() {
+    if [[ "$ORCA_IS_ALLOWED_FAILURE" == "TRUE" ]]; then
+        exit 0
+    fi
+}
+
+trap shutdown ERR
 
 # Make the shell print all lines in the script before executing them.
 set -v

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -37,4 +37,3 @@ if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
 
-echo "completed"

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -37,4 +37,4 @@ if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
 
-
+echo "completed"

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -32,8 +32,9 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
     kill -0 $CHROMEDRIVER_PID
   )
 fi
-
+echo $?
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
+  echo $?
 fi
 

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -12,7 +12,7 @@
 cd "$(dirname "$0")" || exit; source _includes.sh
 
 function shutdown() {
-    if (ORCA_IS_ALLOWED_FAILURE === TRUE); then
+    if ($ORCA_IS_ALLOWED_FAILURE === TRUE); then
       return 0;
     fi
 }

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -36,3 +36,5 @@ fi
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
+
+

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -11,7 +11,12 @@
 
 cd "$(dirname "$0")" || exit; source _includes.sh
 
+echo "Debug 1: "$?
+if [[ "$ORCA_JOB" ]]; then
+  eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 
+fi
+echo "Debug 2: "$?
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then
   (
@@ -32,9 +37,9 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
     kill -0 $CHROMEDRIVER_PID
   )
 fi
-echo $?
+
+echo "Debug 3: "$?
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
-  echo $?
 fi
-
+echo "Debug 4: "$?

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -11,20 +11,6 @@
 
 cd "$(dirname "$0")" || exit; source _includes.sh
 
-function shutdown() {
-    if [[ "$ORCA_IS_ALLOWED_FAILURE" == "TRUE" ]]; then
-      return 0
-    fi
-}
-trap shutdown 1 2 3 6
-
-echo "Debug 1: "$?
-if [[ "$ORCA_JOB" ]]; then
-  eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
-
-fi
-echo "Debug 2: "$?
-
 if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then
   (
     cd "$ORCA_YARN_DIR" || exit
@@ -48,3 +34,4 @@ fi
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
+

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -11,6 +11,13 @@
 
 cd "$(dirname "$0")" || exit; source _includes.sh
 
+function shutdown() {
+    if (ORCA_IS_ALLOWED_FAILURE === TRUE); then
+      return 0;
+    fi
+}
+trap shutdown EXIT
+
 echo "Debug 1: "$?
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
@@ -38,12 +45,6 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
   )
 fi
 
-echo "Debug 3: "$?
 if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
-echo "Debug 4: "$?
-
-echo "completed"
-
-echo "Debug 5: "$?

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -43,3 +43,7 @@ if [[ "$ORCA_JOB" ]]; then
   eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi
 echo "Debug 4: "$?
+
+echo "completed"
+
+echo "Debug 5: "$?

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -11,9 +11,7 @@
 
 cd "$(dirname "$0")" || exit; source _includes.sh
 
-if [[ "$ORCA_JOB" ]]; then
-  eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
-fi
+
 
 if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" && -d "$ORCA_YARN_DIR" ]]; then
   (
@@ -33,4 +31,8 @@ if [[ "$ORCA_ENABLE_NIGHTWATCH" == "TRUE" && "$ORCA_SUT_HAS_NIGHTWATCH_TESTS" &&
     kill -0 $SERVER_PID
     kill -0 $CHROMEDRIVER_PID
   )
+fi
+
+if [[ "$ORCA_JOB" ]]; then
+  eval "orca ci:run $ORCA_JOB script $ORCA_SUT_NAME"
 fi

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -12,8 +12,8 @@
 cd "$(dirname "$0")" || exit; source _includes.sh
 
 function shutdown() {
-    if ($ORCA_IS_ALLOWED_FAILURE === TRUE); then
-      return 0;
+    if [[ "$ORCA_IS_ALLOWED_FAILURE" == "TRUE" ]]; then
+      return 0
     fi
 }
 trap shutdown EXIT

--- a/bin/ci/script.sh
+++ b/bin/ci/script.sh
@@ -16,7 +16,7 @@ function shutdown() {
       return 0
     fi
 }
-trap shutdown EXIT
+trap shutdown 1 2 3 6
 
 echo "Debug 1: "$?
 if [[ "$ORCA_JOB" ]]; then

--- a/composer.lock
+++ b/composer.lock
@@ -4039,16 +4039,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.2.7",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
-                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a1b31d88c0e998168ca7792f222cbecee47428c4",
+                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4",
                 "shasum": ""
             },
             "require": {
@@ -4083,7 +4083,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.2.7"
+                "source": "https://github.com/symfony/finder/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -4099,7 +4099,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:57:23+00:00"
+            "time": "2023-09-26T12:56:25+00:00"
         },
         {
             "name": "symfony/http-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4103,16 +4103,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.3.0",
+            "version": "v6.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "b2f892c91e4e02a939edddeb7ef452522d10a424"
+                "reference": "cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/b2f892c91e4e02a939edddeb7ef452522d10a424",
-                "reference": "b2f892c91e4e02a939edddeb7ef452522d10a424",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d",
+                "reference": "cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d",
                 "shasum": ""
             },
             "require": {
@@ -4175,7 +4175,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.3.0"
+                "source": "https://github.com/symfony/http-client/tree/v6.3.7"
             },
             "funding": [
                 {
@@ -4191,7 +4191,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-12T08:49:48+00:00"
+            "time": "2023-10-29T12:41:36+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -7503,5 +7503,5 @@
         "ext-sqlite3": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Console/Command/Ci/CiRunCommand.php
+++ b/src/Console/Command/Ci/CiRunCommand.php
@@ -142,8 +142,8 @@ class CiRunCommand extends Command {
       $data['status'] = 'FAIL';
       $job = $this->ciJobFactory->create($options->getJob());
       $data['version'] = $job->getDrupalCoreVersion();
-      $data['allowedToFail'] = $this->env->get("ORCA_IS_ALLOWED_FAILURE") ?? FALSE;
-      $data['branch'] = $this->env->get("ORCA_SUT_BRANCH") ?? FALSE;
+      $data['allowedToFail'] = $this->env->get("ORCA_IS_ALLOWED_FAILURE", FALSE);
+      $data['branch'] = $this->env->get("ORCA_SUT_BRANCH", FALSE);
       $job->run($options);
 
     }

--- a/src/Console/Command/Ci/CiRunCommand.php
+++ b/src/Console/Command/Ci/CiRunCommand.php
@@ -8,6 +8,7 @@ use Acquia\Orca\Enum\CiJobPhaseEnum;
 use Acquia\Orca\Enum\StatusCodeEnum;
 use Acquia\Orca\Event\CiEvent;
 use Acquia\Orca\Exception\OrcaInvalidArgumentException;
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Options\CiRunOptionsFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -47,6 +48,13 @@ class CiRunCommand extends Command {
   private $eventDispatcher;
 
   /**
+   * The environment facade.
+   *
+   * @var \Acquia\Orca\Helper\EnvFacade
+   */
+  private EnvFacade $env;
+
+  /**
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Domain\Ci\CiJobFactory $job_factory
@@ -55,11 +63,14 @@ class CiRunCommand extends Command {
    *   The CI run options factory.
    * @param \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher
    *   The event dispatcher service.
+   * @param \Acquia\Orca\Helper\EnvFacade $env
+   *   The environment facade.
    */
-  public function __construct(CiJobFactory $job_factory, CiRunOptionsFactory $ci_run_options_factory, EventDispatcher $eventDispatcher) {
+  public function __construct(CiJobFactory $job_factory, CiRunOptionsFactory $ci_run_options_factory, EventDispatcher $eventDispatcher, EnvFacade $env) {
     $this->ciJobFactory = $job_factory;
     $this->ciRunOptionsFactory = $ci_run_options_factory;
     $this->eventDispatcher = $eventDispatcher;
+    $this->env = $env;
     parent::__construct(self::$defaultName);
   }
 
@@ -131,6 +142,7 @@ class CiRunCommand extends Command {
       $data['status'] = 'FAIL';
       $job = $this->ciJobFactory->create($options->getJob());
       $data['version'] = $job->getDrupalCoreVersion();
+      $data['allowedToFail'] = $this->env->get("ORCA_IS_ALLOWED_FAILURE") ?? FALSE;
       $job->run($options);
 
     }

--- a/src/Console/Command/Ci/CiRunCommand.php
+++ b/src/Console/Command/Ci/CiRunCommand.php
@@ -143,6 +143,7 @@ class CiRunCommand extends Command {
       $job = $this->ciJobFactory->create($options->getJob());
       $data['version'] = $job->getDrupalCoreVersion();
       $data['allowedToFail'] = $this->env->get("ORCA_IS_ALLOWED_FAILURE") ?? FALSE;
+      $data['branch'] = $this->env->get("ORCA_SUT_BRANCH") ?? FALSE;
       $job->run($options);
 
     }

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -64,7 +64,7 @@ class GoogleApiClient {
   /**
    * The sheet id of the spreadsheet.
    */
-  private const SHEET_ID = "Sheet1";
+  private const SHEET_ID = "Sheet2";
 
   /**
    * Constructs an instance.

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -144,6 +144,7 @@ class GoogleApiClient {
             PHP_VERSION,
             $data['status'],
             $data['allowedToFail'],
+            $data['branch'],
           ],
         ],
       ],

--- a/src/Helper/Log/GoogleApiClient.php
+++ b/src/Helper/Log/GoogleApiClient.php
@@ -64,7 +64,7 @@ class GoogleApiClient {
   /**
    * The sheet id of the spreadsheet.
    */
-  private const SHEET_ID = "Sheet2";
+  private const SHEET_ID = "Sheet1";
 
   /**
    * Constructs an instance.

--- a/tests/Console/Command/Ci/CiRunCommandTest.php
+++ b/tests/Console/Command/Ci/CiRunCommandTest.php
@@ -60,7 +60,7 @@ class CiRunCommandTest extends CommandTestBase {
       ->willReturn(new \stdClass());
     $this->env = $this->prophesize(EnvFacade::class);
     $this->env
-      ->get(Argument::any())
+      ->get(Argument::any(), FALSE)
       ->willReturn(NULL);
   }
 

--- a/tests/Console/Command/Ci/CiRunCommandTest.php
+++ b/tests/Console/Command/Ci/CiRunCommandTest.php
@@ -61,7 +61,7 @@ class CiRunCommandTest extends CommandTestBase {
     $this->env = $this->prophesize(EnvFacade::class);
     $this->env
       ->get(Argument::any())
-      ->willReturn();
+      ->willReturn(NULL);
   }
 
   protected function createCommand(): Command {

--- a/tests/Console/Command/Ci/CiRunCommandTest.php
+++ b/tests/Console/Command/Ci/CiRunCommandTest.php
@@ -9,6 +9,7 @@ use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Enum\CiJobPhaseEnum;
 use Acquia\Orca\Enum\StatusCodeEnum;
 use Acquia\Orca\Exception\OrcaInvalidArgumentException;
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Options\CiRunOptions;
 use Acquia\Orca\Options\CiRunOptionsFactory;
 use Acquia\Orca\Tests\Console\Command\CommandTestBase;
@@ -24,6 +25,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @property \Acquia\Orca\Domain\Ci\Job\AbstractCiJob|\Prophecy\Prophecy\ObjectProphecy $ciJob
  * @property \Acquia\Orca\Options\CiRunOptionsFactory|\Prophecy\Prophecy\ObjectProphecy $ciRunOptionsFactory
  * @property \Acquia\Orca\Options\CiRunOptions|\Prophecy\Prophecy\ObjectProphecy $ciRunOptions
+ * @property \Symfony\Component\EventDispatcher\EventDispatcher|\Prophecy\Prophecy\ObjectProphecy $eventDispatcher
+ * @property \Acquia\Orca\Helper\EnvFacade|\Prophecy\Prophecy\ObjectProphecy $env
  * @coversDefaultClass \Acquia\Orca\Console\Command\Ci\CiRunCommand
  */
 class CiRunCommandTest extends CommandTestBase {
@@ -35,6 +38,7 @@ class CiRunCommandTest extends CommandTestBase {
   protected CiRunOptionsFactory|ObjectProphecy $ciRunOptionsFactory;
   protected CiRunOptions|ObjectProphecy $ciRunOptions;
   protected EventDispatcher|ObjectProphecy $eventDispatcher;
+  protected EnvFacade|ObjectProphecy $env;
 
   protected function setUp(): void {
     $this->ciRunOptions = $this->prophesize(CiRunOptions::class);
@@ -54,13 +58,18 @@ class CiRunCommandTest extends CommandTestBase {
     $this->eventDispatcher
       ->dispatch(Argument::cetera())
       ->willReturn(new \stdClass());
+    $this->env = $this->prophesize(EnvFacade::class);
+    $this->env
+      ->get(Argument::any())
+      ->willReturn();
   }
 
   protected function createCommand(): Command {
     $ci_run_options_factory = $this->ciRunOptionsFactory->reveal();
     $ci_job_factory = $this->ciJobFactory->reveal();
     $event_dispatcher = $this->eventDispatcher->reveal();
-    return new CiRunCommand($ci_job_factory, $ci_run_options_factory, $event_dispatcher);
+    $env = $this->env->reveal();
+    return new CiRunCommand($ci_job_factory, $ci_run_options_factory, $event_dispatcher, $env);
   }
 
   private function validSutName(): string {

--- a/tests/Helper/Log/GoogleApiClientTest.php
+++ b/tests/Helper/Log/GoogleApiClientTest.php
@@ -80,6 +80,7 @@ class GoogleApiClientTest extends TestCase {
       'status' => 'PASS',
       'version' => NULL,
       'allowedToFail' => TRUE,
+      'branch' => 'main',
     ];
     $this->version
       ->resolvePredefined(Argument::any())
@@ -101,6 +102,7 @@ class GoogleApiClientTest extends TestCase {
       'status' => 'PASS',
       'version' => DrupalCoreVersionEnum::CURRENT(),
       'allowedToFail' => TRUE,
+      'branch' => 'main',
     ];
     $this->version
       ->existsPredefined(Argument::any())


### PR DESCRIPTION
- This adds "AllowedToFail" information in Domo charts so that we can clearly segregate tests that are actual failures and those which are allowed failures.
- This adds "Branch" information in Domo charts so that SUT branch is reported in dashboard.
- Run NIghtwatch tests before other Phpunit tests so that Nightwatch tests results can be posted in Domo.