### PR TITLE
Orca 572: Run ACMS Command

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -39,45 +39,45 @@ jobs:
     strategy:
       matrix:
         orca-job:
-          - STATIC_CODE_ANALYSIS
-          - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
-          - INTEGRATED_TEST_ON_PREVIOUS_MINOR
-          - INTEGRATED_TEST_ON_LATEST_LTS
+#          - STATIC_CODE_ANALYSIS
+#          - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
+#          - INTEGRATED_TEST_ON_PREVIOUS_MINOR
+#          - INTEGRATED_TEST_ON_LATEST_LTS
           # - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
           - INTEGRATED_TEST_ON_CURRENT
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
-          - ISOLATED_TEST_ON_CURRENT_DEV
-          - INTEGRATED_TEST_ON_CURRENT_DEV
-          - STRICT_DEPRECATED_CODE_SCAN
-          - ISOLATED_TEST_ON_NEXT_MINOR
-          - INTEGRATED_TEST_ON_NEXT_MINOR
+#          - ISOLATED_TEST_ON_CURRENT_DEV
+#          - INTEGRATED_TEST_ON_CURRENT_DEV
+#          - STRICT_DEPRECATED_CODE_SCAN
+#          - ISOLATED_TEST_ON_NEXT_MINOR
+#          - INTEGRATED_TEST_ON_NEXT_MINOR
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
-          - DEPRECATED_CODE_SCAN_W_CONTRIB
-          - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
-          - ISOLATED_TEST_ON_NEXT_MINOR_DEV
+#          - DEPRECATED_CODE_SCAN_W_CONTRIB
+#          - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
+#          - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
-          - LOOSE_DEPRECATED_CODE_SCAN
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+#          - LOOSE_DEPRECATED_CODE_SCAN
+#          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+#          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+#          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "8.1" ]
         orca-enable-nightwatch: [ "FALSE" ]
         orca-coverage-enable: [ "FALSE" ]
-        include:
-          # Testing Drupal 10 in php 8.1 with nightwatch and coverage.
-          - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "8.1"
-            orca-enable-nightwatch: "TRUE"
-            orca-coverage-enable: "TRUE"
-
-          # Testing Drupal 10 in php 8.2.
-          - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "8.2"
-
-          # Testing latest Drupal 9 in php 8.2.
-          - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
-            php-version: "8.2"
+#        include:
+#          # Testing Drupal 10 in php 8.1 with nightwatch and coverage.
+#          - orca-job: ISOLATED_TEST_ON_CURRENT
+#            php-version: "8.1"
+#            orca-enable-nightwatch: "TRUE"
+#            orca-coverage-enable: "TRUE"
+#
+#          # Testing Drupal 10 in php 8.2.
+#          - orca-job: ISOLATED_TEST_ON_CURRENT
+#            php-version: "8.2"
+#
+#          # Testing latest Drupal 9 in php 8.2.
+#          - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
+#            php-version: "8.2"
 
 
     steps:

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -158,3 +158,4 @@ jobs:
           jobs: ${{ toJSON(needs) }}
       - name: All checks successful
         run: echo "🎉"
+

--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -73,6 +73,8 @@ export DRUPAL_TEST_DB_URL="sqlite://localhost/sites/default/files/db.sqlite"
 export DRUPAL_TEST_WEBDRIVER_CHROME_ARGS="--disable-gpu --headless --no-sandbox"
 export DRUPAL_TEST_WEBDRIVER_HOSTNAME="localhost"
 export DRUPAL_TEST_WEBDRIVER_PORT="4444"
+export SITESTUDIO_API_KEY="key-cohesion-baseline"
+export SITESTUDIO_ORG_KEY="test-cohesion-baseline"
 
 if [[ ! "$ORCA_TEMP_DIR" ]]; then
   # GitHub Actions.

--- a/config/services.yml
+++ b/config/services.yml
@@ -14,8 +14,6 @@ parameters:
   env(ORCA_PHPCS_STANDARD): "AcquiaDrupalTransitional"
   env(ORCA_TELEMETRY_ENABLE): "false"
   env(ORCA_IS_ALLOWED_FAILURE): "%env(ORCA_IS_ALLOWED_FAILURE)%"
-  env(SITESTUDIO_API_KEY): "key-cohesion-baseline"
-  env(SITESTUDIO_ORG_KEY): "test-cohesion-baseline"
 
 services:
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -14,6 +14,8 @@ parameters:
   env(ORCA_PHPCS_STANDARD): "AcquiaDrupalTransitional"
   env(ORCA_TELEMETRY_ENABLE): "false"
   env(ORCA_IS_ALLOWED_FAILURE): "%env(ORCA_IS_ALLOWED_FAILURE)%"
+  env(SITESTUDIO_API_KEY): "key-cohesion-baseline"
+  env(SITESTUDIO_ORG_KEY): "test-cohesion-baseline"
 
 services:
 

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -943,7 +943,7 @@ class FixtureCreator {
    * Runs ACMS commands.
    */
   public function runAcmsCommands(): void {
-    if($this->fixtureInspector->getInstalledPackageVersionPretty('acquia/acquia_cms') === '~'){
+    if ($this->fixtureInspector->getInstalledPackageVersionPretty('acquia/acquia_cms') === '~') {
       return;
     }
     $this->output->section('Run ACMS Site Build');

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -230,6 +230,7 @@ class FixtureCreator {
     $this->removeComposerConfigPlatform();
     $this->replaceCoreRecommendedWithCore();
     $this->fixDefaultDependencies();
+    $this->runAcmsCommands();
     $this->addAllowedComposerPlugins();
     $this->addCompanyPackages();
     $this->composer->updateLockFile();
@@ -237,7 +238,6 @@ class FixtureCreator {
     $this->ensureDrupalSettings();
     $this->installSite();
     $this->setUpFilesDirectories();
-    $this->runAcmsCommands();
     $this->customizeFixture();
     $this->createAndCheckoutBackupTag();
     $this->displaySecurityVulnerabilityAdvisories();

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -943,6 +943,9 @@ class FixtureCreator {
    * Runs ACMS commands.
    */
   public function runAcmsCommands(): void {
+    if($this->fixtureInspector->getInstalledPackageVersionPretty('acquia/acquia_cms') === '~'){
+      return;
+    }
     $this->output->section('Run ACMS Site Build');
     $this->processRunner->runFixtureVendorBin(['acms', 'acms:build', '--no-interaction']);
     $this->output->section('Run ACMS Site Install');

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -237,7 +237,7 @@ class FixtureCreator {
     $this->ensureDrupalSettings();
     $this->installSite();
     $this->setUpFilesDirectories();
-    $this->runACMSCommands();
+    $this->runAcmsCommands();
     $this->customizeFixture();
     $this->createAndCheckoutBackupTag();
     $this->displaySecurityVulnerabilityAdvisories();
@@ -940,13 +940,13 @@ class FixtureCreator {
   }
 
   /**
-   * @return void
+   * Runs ACMS commands.
    */
-  public function runACMSCommands(): void {
+  public function runAcmsCommands(): void {
     $this->output->section('Run ACMS Site Build');
-    $this->processRunner->runFixtureVendorBin(['acms','acms:build']);
+    $this->processRunner->runFixtureVendorBin(['acms', 'acms:build']);
     $this->output->section('Run ACMS Site Install');
-    $this->processRunner->runFixtureVendorBin(['acms','acms:install']);
+    $this->processRunner->runFixtureVendorBin(['acms', 'acms:install']);
   }
 
   /**

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -237,6 +237,7 @@ class FixtureCreator {
     $this->ensureDrupalSettings();
     $this->installSite();
     $this->setUpFilesDirectories();
+    $this->runACMSCommands();
     $this->customizeFixture();
     $this->createAndCheckoutBackupTag();
     $this->displaySecurityVulnerabilityAdvisories();
@@ -936,6 +937,16 @@ class FixtureCreator {
       '-R',
       '0770',
     ], $directories));
+  }
+
+  /**
+   * @return void
+   */
+  public function runACMSCommands(): void {
+    $this->output->section('Run ACMS Site Build');
+    $this->processRunner->runFixtureVendorBin(['acms','acms:build']);
+    $this->output->section('Run ACMS Site Install');
+    $this->processRunner->runFixtureVendorBin(['acms','acms:install']);
   }
 
   /**

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -944,9 +944,9 @@ class FixtureCreator {
    */
   public function runAcmsCommands(): void {
     $this->output->section('Run ACMS Site Build');
-    $this->processRunner->runFixtureVendorBin(['acms', 'acms:build']);
+    $this->processRunner->runFixtureVendorBin(['acms', 'acms:build', '--no-interaction']);
     $this->output->section('Run ACMS Site Install');
-    $this->processRunner->runFixtureVendorBin(['acms', 'acms:install']);
+    $this->processRunner->runFixtureVendorBin(['acms', 'acms:install', '--no-interaction']);
   }
 
   /**

--- a/src/Enum/EnvVarEnum.php
+++ b/src/Enum/EnvVarEnum.php
@@ -33,6 +33,8 @@ use MyCLabs\Enum\Enum;
  * @method static EnvVarEnum DRUPAL_TEST_WEBDRIVER_CHROME_ARGS()
  * @method static EnvVarEnum DRUPAL_TEST_WEBDRIVER_HOSTNAME()
  * @method static EnvVarEnum DRUPAL_TEST_WEBDRIVER_PORT()
+ * @method static EnvVarEnum SITESTUDIO_API_KEY()
+ * @method static EnvVarEnum SITESTUDIO_ORG_KEY()
  */
 class EnvVarEnum extends Enum {
 
@@ -93,6 +95,10 @@ class EnvVarEnum extends Enum {
   public const DRUPAL_TEST_WEBDRIVER_HOSTNAME = 'DRUPAL_TEST_WEBDRIVER_HOSTNAME';
 
   public const DRUPAL_TEST_WEBDRIVER_PORT = 'DRUPAL_TEST_WEBDRIVER_PORT';
+  public const SITESTUDIO_API_KEY = 'SITESTUDIO_API_KEY';
+  public const SITESTUDIO_ORG_KEY = 'SITESTUDIO_ORG_KEY';
+
+
 
   /**
    * Descriptions for the environment variables.
@@ -131,6 +137,8 @@ class EnvVarEnum extends Enum {
       self::DRUPAL_TEST_WEBDRIVER_CHROME_ARGS => 'The Chrome WebDriver arguments (Read-only)',
       self::DRUPAL_TEST_WEBDRIVER_HOSTNAME => 'The WebDriver hostname (Read-only)',
       self::DRUPAL_TEST_WEBDRIVER_PORT => 'The WebDriver port (Read-only)',
+      self::SITESTUDIO_API_KEY => 'The Site Studio API Key',
+      self::SITESTUDIO_ORG_KEY => 'The Site Studio ORG Key',
     ];
   }
 


### PR DESCRIPTION
- We are trying to run the `acms:build` and the `acms:install` commands after ORCA's fixture creation in fixtures which contain ACMS, so that we can adequately replicate customer's installation experience.
- We are adding couple of environment variables i.e. SITESTUDIO_API_KEY and SITESTUDIO_ORG_KEY