### PR TITLE
Modify DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY variable to discover SUT

### DIFF
--- a/bin/ci/_includes.sh
+++ b/bin/ci/_includes.sh
@@ -73,6 +73,7 @@ export DRUPAL_TEST_DB_URL="sqlite://localhost/sites/default/files/db.sqlite"
 export DRUPAL_TEST_WEBDRIVER_CHROME_ARGS="--disable-gpu --headless --no-sandbox"
 export DRUPAL_TEST_WEBDRIVER_HOSTNAME="localhost"
 export DRUPAL_TEST_WEBDRIVER_PORT="4444"
+export DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY=../../
 
 if [[ ! "$ORCA_TEMP_DIR" ]]; then
   # GitHub Actions.


### PR DESCRIPTION
After Drupal 10.2.0 release we are observing that Drupal is not detecting Nightwatch tests contained in the SUT. This happens because the SUT present in the `contrib` folder is only symlink to the actual SUT directory which is present adjacent to ORCA fixture directory. This PR tells Drupal to look for Nighwatch tests present in the actual SUT directory.