### PR TITLE
Gitlab directory name mismatch fix

### DIFF
--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -401,9 +401,12 @@ class FixtureCreator {
    *   If the SUT isn't properly installed.
    */
   private function addTopLevelAcquiaPackages(): void {
+    $this->output->section('Adding top level packages');
     $this->addPathRepositories();
+
     $this->addAssetPackagistPathRepositories();
     $this->configureComposerForTopLevelCompanyPackages();
+    $this->output->section('Adding composer require top level packages');
     $this->composerRequireTopLevelCompanyPackages();
     $this->verifySut();
     $this->addSutAllowedPluginsToRootComposer();
@@ -500,8 +503,11 @@ class FixtureCreator {
    * @throws \Acquia\Orca\Exception\OrcaException
    */
   private function composerRequireTopLevelCompanyPackages(): void {
+    $this->output->section('require top level packages 1');
     $packages = $this->getCompanyPackageDependencies();
+    $this->output->section('require top level packages 2');
     $prefer_source = $this->options->preferSource();
+    $this->output->section('require top level packages 3');
     $this->composer->requirePackages($packages, $prefer_source);
   }
 

--- a/src/Domain/Fixture/FixtureCreator.php
+++ b/src/Domain/Fixture/FixtureCreator.php
@@ -401,12 +401,9 @@ class FixtureCreator {
    *   If the SUT isn't properly installed.
    */
   private function addTopLevelAcquiaPackages(): void {
-    $this->output->section('Adding top level packages');
     $this->addPathRepositories();
-
     $this->addAssetPackagistPathRepositories();
     $this->configureComposerForTopLevelCompanyPackages();
-    $this->output->section('Adding composer require top level packages');
     $this->composerRequireTopLevelCompanyPackages();
     $this->verifySut();
     $this->addSutAllowedPluginsToRootComposer();
@@ -503,11 +500,8 @@ class FixtureCreator {
    * @throws \Acquia\Orca\Exception\OrcaException
    */
   private function composerRequireTopLevelCompanyPackages(): void {
-    $this->output->section('require top level packages 1');
     $packages = $this->getCompanyPackageDependencies();
-    $this->output->section('require top level packages 2');
     $prefer_source = $this->options->preferSource();
-    $this->output->section('require top level packages 3');
     $this->composer->requirePackages($packages, $prefer_source);
   }
 

--- a/src/Domain/Package/Package.php
+++ b/src/Domain/Package/Package.php
@@ -226,7 +226,7 @@ class Package {
    * Gets the absolute URL for the Composer "path" repository.
    *
    * @return string
-   *   The absolute URL the Composer package is cloned at at, e.g.,
+   *   The absolute URL the Composer package is cloned at, e.g.,
    *   "/var/www/example".
    */
   public function getRepositoryUrlAbsolute(): string {

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -283,8 +283,7 @@ class PackageManager {
   /**
    * Checks if a package is null.
    */
-  private function containsValidVersion($data) : bool {
-
+  private function containsValidVersion($data): bool {
     if (!is_array($data)) {
       return FALSE;
     }
@@ -300,11 +299,8 @@ class PackageManager {
    * Adds a package to the list of packages.
    */
   private function addPackage(array $datum, FixturePathHandler $fixture_path_handler, string $package_name): void {
-    $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
-    if (empty($datum['url']) && !is_null($orca_sut_dir)) {
-      $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
-      $package_name_parts = explode('/', $orca_sut_dir);
-      $datum['url'] = "../" . end($package_name_parts);
+    if ($this->env->get('ORCA_SUT_NAME') === $package_name) {
+      $datum = $this->setSutUrl($datum);
     }
     $package = new Package($datum, $fixture_path_handler, $this->orca, $package_name);
     $this->packages[$package_name] = $package;
@@ -326,6 +322,21 @@ class PackageManager {
     $default_packages_yaml = $this->orca->getPath('config/packages.yml');
     $data = $this->parser->parseFile($default_packages_yaml);
     $this->blt = new Package($data[$package_name], $this->fixture, $this->orca, $package_name);
+  }
+
+  /**
+   * Sets the URL for the SUT.
+   */
+  private function setSutUrl($datum): array {
+    $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
+    if (!empty($datum['url']) || is_null($orca_sut_dir)) {
+      return $datum;
+    }
+
+    $package_name_parts = explode('/', $orca_sut_dir);
+    $datum['url'] = "../" . end($package_name_parts);
+
+    return $datum;
   }
 
 }

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -293,9 +293,11 @@ class PackageManager {
    * Adds a package to the list of packages.
    */
   private function addPackage(array $datum, FixturePathHandler $fixture_path_handler, string $package_name): void {
-//    if(empty($datum['url'])){
-//      $datum['url'] = $this->env->get('ORCA_SUT_DIR', FALSE);
-//    }
+    if(empty($datum['url'])){
+      $orca_sut_dir = $this->env->get('ORCA_SUT_DIR', FALSE);
+      $package_name_parts = explode('/', $orca_sut_dir);
+      $datum['url'] = "../". end($package_name_parts);
+    }
     $package = new Package($datum, $fixture_path_handler, $this->orca, $package_name);
     $this->packages[$package_name] = $package;
   }

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Orca\Domain\Package;
 
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Filesystem\FixturePathHandler;
 use Acquia\Orca\Helper\Filesystem\OrcaPathHandler;
 use Symfony\Component\Filesystem\Filesystem;
@@ -62,8 +63,15 @@ class PackageManager {
   private $parser;
 
   /**
+   * @var \Acquia\Orca\Helper\EnvFacade
+   */
+  private EnvFacade $env;
+
+  /**
    * Constructs an instance.
    *
+   * @param \Acquia\Orca\Helper\EnvFacade $envFacade
+   *    The environment facade.
    * @param \Symfony\Component\Filesystem\Filesystem $filesystem
    *   The filesystem.
    * @param \Acquia\Orca\Helper\Filesystem\FixturePathHandler $fixture_path_handler
@@ -80,7 +88,8 @@ class PackageManager {
    *   project directory whose contents will be merged into the main packages
    *   configuration.
    */
-  public function __construct(Filesystem $filesystem, FixturePathHandler $fixture_path_handler, OrcaPathHandler $orca_path_handler, Parser $parser, string $packages_config, ?string $packages_config_alter) {
+  public function __construct(EnvFacade $envFacade, Filesystem $filesystem, FixturePathHandler $fixture_path_handler, OrcaPathHandler $orca_path_handler, Parser $parser, string $packages_config, ?string $packages_config_alter) {
+    $this->env = $envFacade;
     $this->filesystem = $filesystem;
     $this->fixture = $fixture_path_handler;
     $this->orca = $orca_path_handler;
@@ -284,6 +293,9 @@ class PackageManager {
    * Adds a package to the list of packages.
    */
   private function addPackage(array $datum, FixturePathHandler $fixture_path_handler, string $package_name): void {
+//    if(empty($datum['url'])){
+//      $datum['url'] = $this->env->get('ORCA_SUT_DIR', FALSE);
+//    }
     $package = new Package($datum, $fixture_path_handler, $this->orca, $package_name);
     $this->packages[$package_name] = $package;
   }

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -216,11 +216,11 @@ class PackageManager {
   private function initializePackages(FixturePathHandler $fixture_path_handler, string $packages_config, ?string $packages_config_alter): void {
     $data = $this->parseYamlFile($this->orca->getPath($packages_config));
     if ($packages_config_alter) {
-      if (!$this->filesystem->isAbsolutePath($packages_config_alter)) {
-        $alter_path = $this->orca->getPath($packages_config_alter);
+      if ($this->filesystem->isAbsolutePath($packages_config_alter)) {
+        $alter_path = $packages_config_alter;
       }
       else {
-        $alter_path = $packages_config_alter;
+        $alter_path = $this->orca->getPath($packages_config_alter);
       }
       $this->alterData = $this->parseYamlFile($alter_path);
       $data = array_merge($data, $this->alterData);

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -299,7 +299,7 @@ class PackageManager {
     if (empty($datum['url']) && !is_null($orca_sut_dir)) {
       $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
       $package_name_parts = explode('/', $orca_sut_dir);
-      $datum['url'] = $package_name_parts;
+      $datum['url'] = "../" . end($package_name_parts);
     }
     $package = new Package($datum, $fixture_path_handler, $this->orca, $package_name);
     $this->packages[$package_name] = $package;

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -216,7 +216,12 @@ class PackageManager {
   private function initializePackages(FixturePathHandler $fixture_path_handler, string $packages_config, ?string $packages_config_alter): void {
     $data = $this->parseYamlFile($this->orca->getPath($packages_config));
     if ($packages_config_alter) {
-      $alter_path = $this->orca->getPath($packages_config_alter);
+      if (!$this->filesystem->isAbsolutePath($packages_config_alter)) {
+        $alter_path = $this->orca->getPath($packages_config_alter);
+      }
+      else {
+        $alter_path = $packages_config_alter;
+      }
       $this->alterData = $this->parseYamlFile($alter_path);
       $data = array_merge($data, $this->alterData);
     }

--- a/src/Domain/Package/PackageManager.php
+++ b/src/Domain/Package/PackageManager.php
@@ -63,6 +63,8 @@ class PackageManager {
   private $parser;
 
   /**
+   * The environment facade.
+   *
    * @var \Acquia\Orca\Helper\EnvFacade
    */
   private EnvFacade $env;
@@ -71,7 +73,7 @@ class PackageManager {
    * Constructs an instance.
    *
    * @param \Acquia\Orca\Helper\EnvFacade $envFacade
-   *    The environment facade.
+   *   The environment facade.
    * @param \Symfony\Component\Filesystem\Filesystem $filesystem
    *   The filesystem.
    * @param \Acquia\Orca\Helper\Filesystem\FixturePathHandler $fixture_path_handler
@@ -293,10 +295,11 @@ class PackageManager {
    * Adds a package to the list of packages.
    */
   private function addPackage(array $datum, FixturePathHandler $fixture_path_handler, string $package_name): void {
-    if(empty($datum['url'])){
-      $orca_sut_dir = $this->env->get('ORCA_SUT_DIR', FALSE);
+    $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
+    if (empty($datum['url']) && !is_null($orca_sut_dir)) {
+      $orca_sut_dir = $this->env->get('ORCA_SUT_DIR');
       $package_name_parts = explode('/', $orca_sut_dir);
-      $datum['url'] = "../". end($package_name_parts);
+      $datum['url'] = $package_name_parts;
     }
     $package = new Package($datum, $fixture_path_handler, $this->orca, $package_name);
     $this->packages[$package_name] = $package;

--- a/tests/Domain/Package/PackageManagerTest.php
+++ b/tests/Domain/Package/PackageManagerTest.php
@@ -121,6 +121,9 @@ class PackageManagerTest extends TestCase {
     $this->env = $this->prophesize(EnvFacade::class);
     $this->filesystem = $this->prophesize(Filesystem::class);
     $this->filesystem
+      ->isAbsolutePath(Argument::any())
+      ->willReturn(TRUE);
+    $this->filesystem
       ->exists(Argument::any())
       ->willReturn(TRUE);
     $this->fixture = $this->prophesize(FixturePathHandler::class);

--- a/tests/Domain/Package/PackageManagerTest.php
+++ b/tests/Domain/Package/PackageManagerTest.php
@@ -188,8 +188,7 @@ class PackageManagerTest extends TestCase {
     self::assertEquals('drupal/module2', $package->getPackageName(), 'Got package by name.');
     self::assertEquals(self::EXPECTED_DEPENDENCY_LIST, $actual_dependency_list, 'Set/got all dependencies.');
     self::assertEquals(TRUE, $package->isCompanyPackage(), 'Got a company package.');
-    self::assertEquals(FALSE, $manager->get('drupal/dependency1')
-      ->isCompanyPackage(), 'Got a third party dependency.');
+    self::assertEquals(FALSE, $manager->get('drupal/dependency1')->isCompanyPackage(), 'Got a third party dependency.');
   }
 
   public function testRequestingNonExistentPackage(): void {

--- a/tests/Domain/Package/PackageManagerTest.php
+++ b/tests/Domain/Package/PackageManagerTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Orca\Tests\Domain\Package;
 
 use Acquia\Orca\Domain\Package\Package;
 use Acquia\Orca\Domain\Package\PackageManager;
+use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Filesystem\FixturePathHandler;
 use Acquia\Orca\Helper\Filesystem\OrcaPathHandler;
 use Acquia\Orca\Tests\TestCase;
@@ -114,8 +115,10 @@ class PackageManagerTest extends TestCase {
   protected ObjectProphecy|Filesystem $filesystem;
   protected ObjectProphecy|FixturePathHandler $fixture;
   protected ObjectProphecy|Parser $parser;
+  protected ObjectProphecy|EnvFacade $env;
 
   protected function setUp(): void {
+    $this->env = $this->prophesize(EnvFacade::class);
     $this->filesystem = $this->prophesize(Filesystem::class);
     $this->filesystem
       ->exists(Argument::any())
@@ -141,11 +144,12 @@ class PackageManagerTest extends TestCase {
   }
 
   private function createPackageManager(): PackageManager {
+    $env = $this->env->reveal();
     $filesystem = $this->filesystem->reveal();
     $fixture_path_handler = $this->fixture->reveal();
     $orca_path_handler = $this->orca->reveal();
     $parser = $this->parser->reveal();
-    return new PackageManager($filesystem, $fixture_path_handler, $orca_path_handler, $parser, self::PACKAGES_CONFIG_FILE, self::PACKAGES_CONFIG_ALTER_FILE);
+    return new PackageManager($env, $filesystem, $fixture_path_handler, $orca_path_handler, $parser, self::PACKAGES_CONFIG_FILE, self::PACKAGES_CONFIG_ALTER_FILE);
   }
 
   public function testConstructionAndGetters(): void {


### PR DESCRIPTION
When GitlabCI runs against an MR (created from a forked repository of the module), the CI fails. This is due to the fact that the ORCA_SUT_DIRECTORY environment (i.e $CI_PROJECT_DIR ) resolves to /builds/issue/module_name-issue-number, whereas ORCA anticipates that the last path name should be the module name, like /builds/issue/module_name. 

This PR ensures that ORCA searches for the SUT in the correct place even if its directory name does not match the actual SUT name. 