### PR TITLE
Add Acquia CMS Common module

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -54,6 +54,13 @@ acquia/acquia_cms:
   version: 2.x
   version_dev: 2.x-dev
 
+drupal/acquia_cms_common:
+  core_matrix:
+    10.1.x:
+      version: 3.2.x
+      version_dev: 1.x-dev
+    '*': []
+
 drupal/acquia_connector:
   version: 4.x
   version_dev: 4.x-dev

--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -180,7 +180,6 @@ class PhpUnitTask extends TestFrameworkBase {
       $include = $this->doc->createElement('include');
 
       foreach ($suffixes as $suffix) {
-        echo $suffix;
         $directory = $this->doc->createElement('directory', $this->getPath());
         $directory->setAttribute('suffix', $suffix);
         $include->appendChild($directory);

--- a/src/Domain/Tool/Phpunit/PhpUnitTask.php
+++ b/src/Domain/Tool/Phpunit/PhpUnitTask.php
@@ -180,6 +180,7 @@ class PhpUnitTask extends TestFrameworkBase {
       $include = $this->doc->createElement('include');
 
       foreach ($suffixes as $suffix) {
+        echo $suffix;
         $directory = $this->doc->createElement('directory', $this->getPath());
         $directory->setAttribute('suffix', $suffix);
         $include->appendChild($directory);


### PR DESCRIPTION
ACMS is failing the PREV_MINOR tests as ACMS Common module requires version` 3.2.x` for Drupal `10.1.x`, so adding this module in `packages.yml `with the correct version constraints.