### PR TITLE
ORCA-650: Add Latest EOL Major job

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         orca-job:
           - STATIC_CODE_ANALYSIS
+          - INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
           - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
           - INTEGRATED_TEST_ON_PREVIOUS_MINOR
           - INTEGRATED_TEST_ON_LATEST_LTS

--- a/config/packages.yml
+++ b/config/packages.yml
@@ -56,10 +56,18 @@ acquia/acquia_cms:
 
 drupal/acquia_cms_common:
   core_matrix:
+    '>=10.2.2':
+      version: 3.3.x
+      version_dev: 3.3.x-dev
     10.1.x:
       version: 3.2.x
-      version_dev: 1.x-dev
-    '*': []
+      version_dev: 3.2.x-dev
+    '>=10.0.9 <10.1':
+      version: 3.1.x
+      version_dev: 3.1.x-dev
+    '>=9.5.10 <10.0.9':
+      version: 2.x
+      version_dev: 2.x-dev
 
 drupal/acquia_connector:
   version: 4.x

--- a/src/Domain/Ci/CiJobFactory.php
+++ b/src/Domain/Ci/CiJobFactory.php
@@ -6,7 +6,7 @@ use Acquia\Orca\Domain\Ci\Job\AbstractCiJob;
 use Acquia\Orca\Domain\Ci\Job\DeprecatedCodeScanWContribCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob;
-use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEOLMajorCiJob;
+use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEolMajorCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorDevCiJob;
@@ -51,8 +51,8 @@ class CiJobFactory {
    *   Integrated test on current dev Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob $integrated_test_on_current_dev_ci_job
    *   Integrated test on latest LTS Drupal core version.
-   * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEOLMajorCiJob $integrated_test_on_latest_eol_major_ci_job
-   *    Integrated test on latest EOL major Drupal core version.
+   * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEolMajorCiJob $integrated_test_on_latest_eol_major_ci_job
+   *   Integrated test on latest EOL major Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob $integrated_test_on_latest_lts_ci_job
    *   Integrated test on current Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job
@@ -102,7 +102,7 @@ class CiJobFactory {
     DeprecatedCodeScanWContribCiJob $deprecated_code_scan_w_contrib_ci_job,
     IntegratedTestOnCurrentCiJob $integrated_test_on_current_ci_job,
     IntegratedTestOnCurrentDevCiJob $integrated_test_on_current_dev_ci_job,
-    IntegratedTestOnLatestEOLMajorCiJob $integrated_test_on_latest_eol_major_ci_job,
+    IntegratedTestOnLatestEolMajorCiJob $integrated_test_on_latest_eol_major_ci_job,
     IntegratedTestOnLatestLtsCiJob $integrated_test_on_latest_lts_ci_job,
     IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job,
     IntegratedTestOnNextMajorLatestMinorDevCiJob $integrated_test_on_next_major_latest_minor_dev_ci_job,

--- a/src/Domain/Ci/CiJobFactory.php
+++ b/src/Domain/Ci/CiJobFactory.php
@@ -6,6 +6,7 @@ use Acquia\Orca\Domain\Ci\Job\AbstractCiJob;
 use Acquia\Orca\Domain\Ci\Job\DeprecatedCodeScanWContribCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob;
+use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEOLMajorCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorDevCiJob;
@@ -50,6 +51,8 @@ class CiJobFactory {
    *   Integrated test on current dev Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob $integrated_test_on_current_dev_ci_job
    *   Integrated test on latest LTS Drupal core version.
+   * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEOLMajorCiJob $integrated_test_on_latest_eol_major_ci_job
+   *    Integrated test on latest EOL major Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob $integrated_test_on_latest_lts_ci_job
    *   Integrated test on current Drupal core version.
    * @param \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job
@@ -99,6 +102,7 @@ class CiJobFactory {
     DeprecatedCodeScanWContribCiJob $deprecated_code_scan_w_contrib_ci_job,
     IntegratedTestOnCurrentCiJob $integrated_test_on_current_ci_job,
     IntegratedTestOnCurrentDevCiJob $integrated_test_on_current_dev_ci_job,
+    IntegratedTestOnLatestEOLMajorCiJob $integrated_test_on_latest_eol_major_ci_job,
     IntegratedTestOnLatestLtsCiJob $integrated_test_on_latest_lts_ci_job,
     IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job,
     IntegratedTestOnNextMajorLatestMinorDevCiJob $integrated_test_on_next_major_latest_minor_dev_ci_job,

--- a/src/Domain/Ci/Job/IntegratedTestOnLatestEOLMajorCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestEOLMajorCiJob.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Acquia\Orca\Domain\Ci\Job;
+
+use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
+use Acquia\Orca\Enum\CiJobEnum;
+use Acquia\Orca\Helper\EnvFacade;
+use Acquia\Orca\Helper\Process\ProcessRunner;
+use Acquia\Orca\Options\CiRunOptions;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The integrated test on next minor CI job.
+ */
+class IntegratedTestOnLatestEOLMajorCiJob extends AbstractCiJob {
+
+  /**
+   * The Drupal core version resolver.
+   *
+   * @var \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver
+   */
+  private $drupalCoreVersionResolver;
+
+  /**
+   * The ENV facade.
+   *
+   * @var \Acquia\Orca\Helper\EnvFacade
+   */
+  private $envFacade;
+
+  /**
+   * The output decorator.
+   *
+   * @var \Symfony\Component\Console\Output\OutputInterface
+   */
+  private $output;
+
+  /**
+   * The process runner.
+   *
+   * @var \Acquia\Orca\Helper\Process\ProcessRunner
+   */
+  private $processRunner;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver $drupal_core_version_resolver
+   *   The Drupal core version resolver.
+   * @param \Acquia\Orca\Helper\EnvFacade $env_facade
+   *   The ENV facade.
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *   The output decorator.
+   * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
+   *   The process runner.
+   */
+  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver, EnvFacade $env_facade, OutputInterface $output, ProcessRunner $process_runner) {
+    $this->envFacade = $env_facade;
+    $this->drupalCoreVersionResolver = $drupal_core_version_resolver;
+    $this->output = $output;
+    $this->processRunner = $process_runner;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function jobName(): CiJobEnum {
+    return CiJobEnum::INTEGRATED_TEST_ON_LATEST_EOL_MAJOR();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function install(CiRunOptions $options): void {
+    $this->runOrcaFixtureInit([
+      '--force',
+      "--sut={$options->getSut()->getPackageName()}",
+      "--core={$this->getDrupalCoreVersion()}",
+    ], $this->envFacade, $this->processRunner);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function script(CiRunOptions $options): void {
+    $this->processRunner
+      ->runOrca(['fixture:status']);
+
+    $this->runOrcaQaAutomatedTests([
+      "--sut={$options->getSut()->getPackageName()}",
+    ], $this->envFacade, $this->processRunner);
+  }
+
+}

--- a/src/Domain/Ci/Job/IntegratedTestOnLatestEolMajorCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestEolMajorCiJob.php
@@ -2,12 +2,10 @@
 
 namespace Acquia\Orca\Domain\Ci\Job;
 
-use Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver;
 use Acquia\Orca\Enum\CiJobEnum;
 use Acquia\Orca\Helper\EnvFacade;
 use Acquia\Orca\Helper\Process\ProcessRunner;
 use Acquia\Orca\Options\CiRunOptions;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The integrated test on next minor CI job.
@@ -15,25 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class IntegratedTestOnLatestEolMajorCiJob extends AbstractCiJob {
 
   /**
-   * The Drupal core version resolver.
-   *
-   * @var \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver
-   */
-  private $drupalCoreVersionResolver;
-
-  /**
    * The ENV facade.
    *
    * @var \Acquia\Orca\Helper\EnvFacade
    */
   private $envFacade;
-
-  /**
-   * The output decorator.
-   *
-   * @var \Symfony\Component\Console\Output\OutputInterface
-   */
-  private $output;
 
   /**
    * The process runner.
@@ -45,19 +29,13 @@ class IntegratedTestOnLatestEolMajorCiJob extends AbstractCiJob {
   /**
    * Constructs an instance.
    *
-   * @param \Acquia\Orca\Domain\Composer\Version\DrupalCoreVersionResolver $drupal_core_version_resolver
-   *   The Drupal core version resolver.
    * @param \Acquia\Orca\Helper\EnvFacade $env_facade
    *   The ENV facade.
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *   The output decorator.
    * @param \Acquia\Orca\Helper\Process\ProcessRunner $process_runner
    *   The process runner.
    */
-  public function __construct(DrupalCoreVersionResolver $drupal_core_version_resolver, EnvFacade $env_facade, OutputInterface $output, ProcessRunner $process_runner) {
+  public function __construct(EnvFacade $env_facade, ProcessRunner $process_runner) {
     $this->envFacade = $env_facade;
-    $this->drupalCoreVersionResolver = $drupal_core_version_resolver;
-    $this->output = $output;
     $this->processRunner = $process_runner;
   }
 

--- a/src/Domain/Ci/Job/IntegratedTestOnLatestEolMajorCiJob.php
+++ b/src/Domain/Ci/Job/IntegratedTestOnLatestEolMajorCiJob.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * The integrated test on next minor CI job.
  */
-class IntegratedTestOnLatestEOLMajorCiJob extends AbstractCiJob {
+class IntegratedTestOnLatestEolMajorCiJob extends AbstractCiJob {
 
   /**
    * The Drupal core version resolver.

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -30,7 +30,7 @@ class DrupalCoreVersionResolver {
    *
    * @var string|null
    */
-  private $latestEOLMajor;
+  private $latestEolMajor;
 
   /**
    * The latest LTS Drupal core version.
@@ -134,7 +134,7 @@ class DrupalCoreVersionResolver {
   public function resolvePredefined(DrupalCoreVersionEnum $version): string {
     switch ($version->getValue()) {
       case DrupalCoreVersionEnum::LATEST_EOL_MAJOR():
-        return $this->findLatestEOLMajor();
+        return $this->findLatestEolMajor();
 
       case DrupalCoreVersionEnum::OLDEST_SUPPORTED():
         return $this->findOldestSupported();
@@ -273,19 +273,24 @@ class DrupalCoreVersionResolver {
   }
 
   /**
+   * Finds the latest EOL Major version of Drupal core.
    *
+   * @return string
+   *    The semver version string, e.g., 9.5.11.
+   *
+   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
    */
-  private function findLatestEOLMajor(): string {
-    if ($this->latestEOLMajor) {
-      return $this->latestEOLMajor;
+  private function findLatestEolMajor(): string {
+    if ($this->latestEolMajor) {
+      return $this->latestEolMajor;
     }
 
     $parts = explode('.', $this->findOldestSupported());
     $oldest_supported_major = $parts[0];
 
-    $this->latestEOLMajor = $this
+    $this->latestEolMajor = $this
       ->resolveArbitrary("<{$oldest_supported_major}", 'stable');
-    return $this->latestEOLMajor;
+    return $this->latestEolMajor;
 
   }
 

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -26,6 +26,13 @@ class DrupalCoreVersionResolver {
   private $drupalDotOrgApiClient;
 
   /**
+   * The latest EOL Major Drupal core version.
+   *
+   * @var string|null
+   */
+  private $latestEOLMajor;
+
+  /**
    * The latest LTS Drupal core version.
    *
    * @var string|null
@@ -126,6 +133,9 @@ class DrupalCoreVersionResolver {
    */
   public function resolvePredefined(DrupalCoreVersionEnum $version): string {
     switch ($version->getValue()) {
+      case DrupalCoreVersionEnum::LATEST_EOL_MAJOR():
+        return $this->findLatestEOLMajor();
+
       case DrupalCoreVersionEnum::OLDEST_SUPPORTED():
         return $this->findOldestSupported();
 
@@ -260,6 +270,23 @@ class DrupalCoreVersionResolver {
 
     $message = "No Drupal core version satisfies the given constraints: oldest supported ($oldestSupported) less than current major ($current_major)";
     throw new OrcaVersionNotFoundException($message);
+  }
+
+  /**
+   *
+   */
+  private function findLatestEOLMajor(): string {
+    if ($this->latestEOLMajor) {
+      return $this->latestEOLMajor;
+    }
+
+    $parts = explode('.', $this->findOldestSupported());
+    $oldest_supported_major = $parts[0];
+
+    $this->latestEOLMajor = $this
+      ->resolveArbitrary("<{$oldest_supported_major}", 'stable');
+    return $this->latestEOLMajor;
+
   }
 
   /**

--- a/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
+++ b/src/Domain/Composer/Version/DrupalCoreVersionResolver.php
@@ -221,6 +221,28 @@ class DrupalCoreVersionResolver {
   }
 
   /**
+   * Finds the latest EOL Major version of Drupal core.
+   *
+   * @return string
+   *   The semver version string, e.g., 9.5.11.
+   *
+   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
+   */
+  private function findLatestEolMajor(): string {
+    if ($this->latestEolMajor) {
+      return $this->latestEolMajor;
+    }
+
+    $parts = explode('.', $this->findOldestSupported());
+    $oldest_supported_major = $parts[0];
+
+    $this->latestEolMajor = $this
+      ->resolveArbitrary("<{$oldest_supported_major}", 'stable');
+    return $this->latestEolMajor;
+
+  }
+
+  /**
    * Finds the oldest supported version of Drupal core.
    *
    * @return string
@@ -270,28 +292,6 @@ class DrupalCoreVersionResolver {
 
     $message = "No Drupal core version satisfies the given constraints: oldest supported ($oldestSupported) less than current major ($current_major)";
     throw new OrcaVersionNotFoundException($message);
-  }
-
-  /**
-   * Finds the latest EOL Major version of Drupal core.
-   *
-   * @return string
-   *    The semver version string, e.g., 9.5.11.
-   *
-   * @throws \Acquia\Orca\Exception\OrcaVersionNotFoundException
-   */
-  private function findLatestEolMajor(): string {
-    if ($this->latestEolMajor) {
-      return $this->latestEolMajor;
-    }
-
-    $parts = explode('.', $this->findOldestSupported());
-    $oldest_supported_major = $parts[0];
-
-    $this->latestEolMajor = $this
-      ->resolveArbitrary("<{$oldest_supported_major}", 'stable');
-    return $this->latestEolMajor;
-
   }
 
   /**

--- a/src/Enum/CiJobEnum.php
+++ b/src/Enum/CiJobEnum.php
@@ -8,6 +8,7 @@ use MyCLabs\Enum\Enum;
  * Provides CI job special values.
  *
  * @method static CiJobEnum STATIC_CODE_ANALYSIS()
+ * @method static CiJobEnum INTEGRATED_TEST_ON_LATEST_EOL_MAJOR()
  * @method static CiJobEnum INTEGRATED_TEST_ON_OLDEST_SUPPORTED()
  * @method static CiJobEnum INTEGRATED_TEST_ON_LATEST_LTS()
  * @method static CiJobEnum INTEGRATED_TEST_ON_PREVIOUS_MINOR()
@@ -35,6 +36,8 @@ use MyCLabs\Enum\Enum;
 final class CiJobEnum extends Enum {
 
   public const STATIC_CODE_ANALYSIS = 'STATIC_CODE_ANALYSIS';
+
+  public const INTEGRATED_TEST_ON_LATEST_EOL_MAJOR = 'INTEGRATED_TEST_ON_LATEST_EOL_MAJOR';
 
   public const INTEGRATED_TEST_ON_OLDEST_SUPPORTED = 'INTEGRATED_TEST_ON_OLDEST_SUPPORTED';
 
@@ -91,6 +94,7 @@ final class CiJobEnum extends Enum {
   public static function descriptions(): array {
     return [
       self::STATIC_CODE_ANALYSIS => 'Static code analysis',
+      self::INTEGRATED_TEST_ON_LATEST_EOL_MAJOR => 'Integrated test on latest EOL major Drupal core version',
       self::INTEGRATED_TEST_ON_OLDEST_SUPPORTED => 'Integrated test on oldest supported Drupal core version',
       self::INTEGRATED_TEST_ON_LATEST_LTS => 'Integrated test on latest LTS Drupal core version',
       self::INTEGRATED_TEST_ON_PREVIOUS_MINOR => 'Integrated test on previous minor Drupal core version',
@@ -136,6 +140,9 @@ final class CiJobEnum extends Enum {
    */
   public function getDrupalCoreVersion(): ?DrupalCoreVersionEnum {
     switch ($this->getKey()) {
+      case self::INTEGRATED_TEST_ON_LATEST_EOL_MAJOR():
+        return DrupalCoreVersionEnum::LATEST_EOL_MAJOR();
+
       case self::INTEGRATED_TEST_ON_OLDEST_SUPPORTED:
         return DrupalCoreVersionEnum::OLDEST_SUPPORTED();
 

--- a/src/Enum/DrupalCoreVersionEnum.php
+++ b/src/Enum/DrupalCoreVersionEnum.php
@@ -69,16 +69,16 @@ class DrupalCoreVersionEnum extends Enum {
    */
   public static function examples(): array {
     return [
-      self::LATEST_EOL_MAJOR => '9.5.3',
-      self::OLDEST_SUPPORTED => '10.1.8',
-      self::LATEST_LTS => '~',
-      self::PREVIOUS_MINOR => '10.1.8',
-      self::CURRENT => '10.2.3',
-      self::CURRENT_DEV => '10.2.x-dev',
-      self::NEXT_MINOR => '~',
-      self::NEXT_MINOR_DEV => '11.x-dev',
-      self::NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER => '~',
-      self::NEXT_MAJOR_LATEST_MINOR_DEV => '11.x-dev',
+      self::LATEST_EOL_MAJOR => '7.99',
+      self::OLDEST_SUPPORTED => '8.8.1',
+      self::LATEST_LTS => '8.9.1',
+      self::PREVIOUS_MINOR => '9.1.1',
+      self::CURRENT => '9.2.1',
+      self::CURRENT_DEV => '9.2.x-dev',
+      self::NEXT_MINOR => '9.3.0-alpha1',
+      self::NEXT_MINOR_DEV => '9.3.x-dev',
+      self::NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER => '10.0.0-beta1',
+      self::NEXT_MAJOR_LATEST_MINOR_DEV => '10.0.x-dev',
     ];
   }
 

--- a/src/Enum/DrupalCoreVersionEnum.php
+++ b/src/Enum/DrupalCoreVersionEnum.php
@@ -7,6 +7,7 @@ use MyCLabs\Enum\Enum;
 /**
  * Provides Drupal core version special values.
  *
+ * @method static DrupalCoreVersionEnum LATEST_EOL_MAJOR()
  * @method static DrupalCoreVersionEnum OLDEST_SUPPORTED()
  * @method static DrupalCoreVersionEnum LATEST_LTS()
  * @method static DrupalCoreVersionEnum PREVIOUS_MINOR()
@@ -18,6 +19,8 @@ use MyCLabs\Enum\Enum;
  * @method static DrupalCoreVersionEnum NEXT_MAJOR_LATEST_MINOR_DEV()
  */
 class DrupalCoreVersionEnum extends Enum {
+
+  public const LATEST_EOL_MAJOR = 'LATEST_EOL_MAJOR';
 
   public const OLDEST_SUPPORTED = 'OLDEST_SUPPORTED';
 
@@ -45,6 +48,7 @@ class DrupalCoreVersionEnum extends Enum {
    */
   public static function descriptions(): array {
     return [
+      self::LATEST_EOL_MAJOR => 'Latest EOL Major Drupal core version',
       self::OLDEST_SUPPORTED => 'Oldest supported Drupal core version',
       self::LATEST_LTS => 'Latest LTS Drupal core version',
       self::PREVIOUS_MINOR => 'Previous minor Drupal core version',
@@ -65,15 +69,16 @@ class DrupalCoreVersionEnum extends Enum {
    */
   public static function examples(): array {
     return [
-      self::OLDEST_SUPPORTED => '8.8.1',
-      self::LATEST_LTS => '8.9.1',
-      self::PREVIOUS_MINOR => '9.1.1',
-      self::CURRENT => '9.2.1',
-      self::CURRENT_DEV => '9.2.x-dev',
-      self::NEXT_MINOR => '9.3.0-alpha1',
-      self::NEXT_MINOR_DEV => '9.3.x-dev',
-      self::NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER => '10.0.0-beta1',
-      self::NEXT_MAJOR_LATEST_MINOR_DEV => '10.0.x-dev',
+      self::LATEST_EOL_MAJOR => '9.5.3',
+      self::OLDEST_SUPPORTED => '10.1.8',
+      self::LATEST_LTS => '~',
+      self::PREVIOUS_MINOR => '10.1.8',
+      self::CURRENT => '10.2.3',
+      self::CURRENT_DEV => '10.2.x-dev',
+      self::NEXT_MINOR => '~',
+      self::NEXT_MINOR_DEV => '11.x-dev',
+      self::NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER => '~',
+      self::NEXT_MAJOR_LATEST_MINOR_DEV => '11.x-dev',
     ];
   }
 

--- a/tests/Domain/Ci/CiJobFactoryTest.php
+++ b/tests/Domain/Ci/CiJobFactoryTest.php
@@ -6,6 +6,7 @@ use Acquia\Orca\Domain\Ci\CiJobFactory;
 use Acquia\Orca\Domain\Ci\Job\DeprecatedCodeScanWContribCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob;
+use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEolMajorCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob;
 use Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorDevCiJob;
@@ -36,6 +37,7 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @property \Acquia\Orca\Domain\Ci\Job\DeprecatedCodeScanWContribCiJob|\Prophecy\Prophecy\ObjectProphecy $deprecatedCodeScanWContribCiJob
  * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnCurrentCiJob
  * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnCurrentDevCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnCurrentDevCiJob
+ * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestEolMajorCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnLatestEolMajorCiJob
  * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnLatestLtsCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnLatestLtsCiJob
  * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnNextMajorLatestMinorBetaOrLaterCiJob
  * @property \Acquia\Orca\Domain\Ci\Job\IntegratedTestOnNextMajorLatestMinorDevCiJob|\Prophecy\Prophecy\ObjectProphecy $integratedTestOnNextMajorLatestMinorDevCiJob
@@ -64,6 +66,7 @@ class CiJobFactoryTest extends TestCase {
   protected DeprecatedCodeScanWContribCiJob|ObjectProphecy $deprecatedCodeScanWContribCiJob;
   protected IntegratedTestOnCurrentCiJob|ObjectProphecy $integratedTestOnCurrentCiJob;
   protected IntegratedTestOnCurrentDevCiJob|ObjectProphecy $integratedTestOnCurrentDevCiJob;
+  protected IntegratedTestOnLatestLtsCiJob|ObjectProphecy $integratedTestOnLatestEolMajorCiJob;
   protected IntegratedTestOnLatestLtsCiJob|ObjectProphecy $integratedTestOnLatestLtsCiJob;
   protected IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob|ObjectProphecy $integratedTestOnNextMajorLatestMinorBetaOrLaterCiJob;
   protected IntegratedTestOnNextMajorLatestMinorDevCiJob|ObjectProphecy $integratedTestOnNextMajorLatestMinorDevCiJob;
@@ -90,6 +93,7 @@ class CiJobFactoryTest extends TestCase {
     $this->deprecatedCodeScanWContribCiJob = $this->prophesize(DeprecatedCodeScanWContribCiJob::class);
     $this->integratedTestOnCurrentCiJob = $this->prophesize(IntegratedTestOnCurrentCiJob::class);
     $this->integratedTestOnCurrentDevCiJob = $this->prophesize(IntegratedTestOnCurrentDevCiJob::class);
+    $this->integratedTestOnLatestEolMajorCiJob = $this->prophesize(IntegratedTestOnLatestEolMajorCiJob::class);
     $this->integratedTestOnLatestLtsCiJob = $this->prophesize(IntegratedTestOnLatestLtsCiJob::class);
     $this->integratedTestOnNextMajorLatestMinorBetaOrLaterCiJob = $this->prophesize(IntegratedTestOnNextMajorLatestMinorBetaOrLaterCiJob::class);
     $this->integratedTestOnNextMajorLatestMinorDevCiJob = $this->prophesize(IntegratedTestOnNextMajorLatestMinorDevCiJob::class);
@@ -117,6 +121,7 @@ class CiJobFactoryTest extends TestCase {
     $deprecated_code_scan_w_contrib_ci_job = $this->deprecatedCodeScanWContribCiJob->reveal();
     $integrated_test_on_current_ci_job = $this->integratedTestOnCurrentCiJob->reveal();
     $integrated_test_on_current_dev_ci_job = $this->integratedTestOnCurrentDevCiJob->reveal();
+    $integrated_test_on_latest_eol_major_ci_job = $this->integratedTestOnLatestEolMajorCiJob->reveal();
     $integrated_test_on_latest_lts = $this->integratedTestOnLatestLtsCiJob->reveal();
     $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job = $this->integratedTestOnNextMajorLatestMinorBetaOrLaterCiJob->reveal();
     $integrated_test_on_next_major_latest_minor_dev_ci_job = $this->integratedTestOnNextMajorLatestMinorDevCiJob->reveal();
@@ -142,6 +147,7 @@ class CiJobFactoryTest extends TestCase {
       $deprecated_code_scan_w_contrib_ci_job,
       $integrated_test_on_current_ci_job,
       $integrated_test_on_current_dev_ci_job,
+      $integrated_test_on_latest_eol_major_ci_job,
       $integrated_test_on_latest_lts,
       $integrated_test_on_next_major_latest_minor_beta_or_later_ci_job,
       $integrated_test_on_next_major_latest_minor_dev_ci_job,

--- a/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
+++ b/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
@@ -80,7 +80,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
   public function testExistsPredefinedTrue(): void {
     $this->selector
       ->findBestCandidate('drupal/core', Argument::any(), Argument::any())
-      ->shouldBeCalledTimes(2)
+      ->shouldBeCalled()
       ->willReturn($this->package->reveal());
     $resolver = $this->createDrupalCoreVersionResolver();
 

--- a/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
+++ b/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
@@ -156,7 +156,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
       ->shouldBeCalledOnce();
     $this->package
       ->getPrettyVersion()
-      ->willReturn('10.1.8','9.5.11')
+      ->willReturn('10.1.8', '9.5.11')
       ->shouldBeCalledTimes(2);
     $this->selector
       ->findBestCandidate('drupal/core', '10.1.x', 'stable')

--- a/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
+++ b/tests/Domain/Composer/Version/DrupalCoreVersionResolverTest.php
@@ -80,7 +80,7 @@ class DrupalCoreVersionResolverTest extends TestCase {
   public function testExistsPredefinedTrue(): void {
     $this->selector
       ->findBestCandidate('drupal/core', Argument::any(), Argument::any())
-      ->shouldBeCalledOnce()
+      ->shouldBeCalledTimes(2)
       ->willReturn($this->package->reveal());
     $resolver = $this->createDrupalCoreVersionResolver();
 
@@ -147,6 +147,32 @@ class DrupalCoreVersionResolverTest extends TestCase {
 
     /* @noinspection PhpUnitTestsInspection */
     self::assertTrue(is_string($resolution), 'Accepted version and returned string.');
+  }
+
+  public function testResolvePredefinedLatestEolMajor(): void {
+    $this->drupalDotOrgApiClient
+      ->getOldestSupportedDrupalCoreBranch()
+      ->willReturn('10.1.x')
+      ->shouldBeCalledOnce();
+    $this->package
+      ->getPrettyVersion()
+      ->willReturn('10.1.8','9.5.11')
+      ->shouldBeCalledTimes(2);
+    $this->selector
+      ->findBestCandidate('drupal/core', '10.1.x', 'stable')
+      ->willReturn($this->package->reveal())
+      ->shouldBeCalledTimes(1);
+    $this->selector
+      ->findBestCandidate('drupal/core', '<10', 'stable')
+      ->willReturn($this->package->reveal())
+      ->shouldBeCalledTimes(1);
+    $resolver = $this->createDrupalCoreVersionResolver();
+
+    $actual = $resolver->resolvePredefined(DrupalCoreVersionEnum::LATEST_EOL_MAJOR());
+    // Call again to test value caching.
+    $resolver->resolvePredefined(DrupalCoreVersionEnum::LATEST_EOL_MAJOR());
+
+    self::assertSame('9.5.11', $actual);
   }
 
   public function testResolvePredefinedOldestSupported(): void {


### PR DESCRIPTION
- We are adding a new job which can be used to test latest Drupal version of the last EOL major. This would help testing our products in Drupal 9 as many customers are still in Drupal 9.