### PR TITLE
Allow phploc to pass when there are no files to scan

### DIFF
--- a/.idea/orca.iml
+++ b/.idea/orca.iml
@@ -3,7 +3,6 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Acquia\Orca\" />
-      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Acquia\Orca\Tests\" />
       <excludeFolder url="file://$MODULE_DIR$/var" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />

--- a/src/Domain/Tool/Phploc/PhplocFacade.php
+++ b/src/Domain/Tool/Phploc/PhplocFacade.php
@@ -73,7 +73,7 @@ class PhplocFacade {
       $args[] = '--suffix=' . $extension;
     }
     $args[] = '.';
-    $this->processRunner->runOrcaVendorBin($args, $path);
+    $this->processRunner->runOrcaVendorBin($args, $path, TRUE);
   }
 
 }

--- a/src/Helper/Process/ProcessRunner.php
+++ b/src/Helper/Process/ProcessRunner.php
@@ -67,6 +67,8 @@ class ProcessRunner {
    * @param string|null $cwd
    *   The working directory, or NULL to use the working dir of the current PHP
    *   process.
+   * @param bool $allow_failure
+   *   Allow the process to fail.
    *
    * @return int
    *   The exit status code.
@@ -74,7 +76,7 @@ class ProcessRunner {
    * @throws \Symfony\Component\Process\Exception\ProcessFailedException
    *   If the process is unsuccessful.
    */
-  public function run(Process $process, ?string $cwd = NULL): int {
+  public function run(Process $process, ?string $cwd = NULL, bool $allow_failure = FALSE): int {
     $this->output->writeln(sprintf('> %s', $process->getCommandLine()));
 
     if ($cwd) {
@@ -90,7 +92,7 @@ class ProcessRunner {
         $this->output->write($buffer);
       });
 
-    if (!$process->isSuccessful()) {
+    if (!$allow_failure && !$process->isSuccessful()) {
       $process->disableOutput();
       throw new ProcessFailedException($process);
     }
@@ -194,13 +196,15 @@ class ProcessRunner {
    *   name.
    * @param string|null $cwd
    *   The working directory, or NULL to use the fixture directory.
+   * @param bool $allow_failure
+   *   Allow the process to fail.
    *
    * @return int
    *   The exit status code.
    */
-  public function runOrcaVendorBin(array $command, ?string $cwd = NULL): int {
+  public function runOrcaVendorBin(array $command, ?string $cwd = NULL, bool $allow_failure = FALSE): int {
     $process = $this->createOrcaVendorBinProcess($command);
-    return $this->run($process, $cwd);
+    return $this->run($process, $cwd, $allow_failure);
   }
 
   /**

--- a/tests/Domain/Tool/Phploc/PhplocFacadeTest.php
+++ b/tests/Domain/Tool/Phploc/PhplocFacadeTest.php
@@ -26,7 +26,7 @@ class PhplocFacadeTest extends TestCase {
       ->willReturnArgument();
     $this->processRunner = $this->prophesize(ProcessRunner::class);
     $this->processRunner
-      ->runOrcaVendorBin(Argument::any(), Argument::any())
+      ->runOrcaVendorBin(Argument::cetera())
       ->willReturn(0);
   }
 
@@ -57,7 +57,7 @@ class PhplocFacadeTest extends TestCase {
         '--suffix=.profile',
         '--suffix=.engine',
         '.',
-      ], $path)
+      ], $path, TRUE)
       ->shouldBeCalledOnce();
 
     $phploc->execute($path);


### PR DESCRIPTION
- If there are no files to scan, `phploc` should not fail and stop the execution of the static analysis job.