### PR TITLE
DRP: Modifications required to make ORCA immune to DRP new release

### DIFF
--- a/src/Options/FixtureOptions.php
+++ b/src/Options/FixtureOptions.php
@@ -304,7 +304,10 @@ class FixtureOptions {
       $this->options['project-template'] = 'acquia/drupal-recommended-project:^1';
     }
     elseif ($this->coreVersionParsedMatches('^10') && $this->isDev()) {
-      $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-master';
+      $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-2.x';
+    }
+    elseif ($this->coreVersionParsedMatches('^10')) {
+      $this->options['project-template'] = 'acquia/drupal-recommended-project:^2';
     }
     elseif ($this->coreVersionParsedMatches('^11')) {
       $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-drupal11';

--- a/src/Options/FixtureOptions.php
+++ b/src/Options/FixtureOptions.php
@@ -304,7 +304,7 @@ class FixtureOptions {
       $this->options['project-template'] = 'acquia/drupal-recommended-project:^1';
     }
     elseif ($this->coreVersionParsedMatches('^10') && $this->isDev()) {
-      $this->options['project-template'] = 'acquia/drupal-recommended-project:dev-2.x';
+      $this->options['project-template'] = 'acquia/drupal-recommended-project:2.x-dev';
     }
     elseif ($this->coreVersionParsedMatches('^10')) {
       $this->options['project-template'] = 'acquia/drupal-recommended-project:^2';

--- a/tests/Options/FixtureOptionsTest.php
+++ b/tests/Options/FixtureOptionsTest.php
@@ -80,7 +80,7 @@ class FixtureOptionsTest extends TestCase {
     self::assertFalse($options->symlinkAll(), 'Set/got default "symlink-all" option.');
     self::assertEquals($core, $options->getCore(), 'Set/got default "core" option.');
     self::assertEquals('orca', $options->getProfile(), 'Set/got default "profile" option.');
-    self::assertEquals('acquia/drupal-recommended-project', $options->getProjectTemplate(), 'Set/got default "project-template" option.');
+    self::assertEquals('acquia/drupal-recommended-project:^2', $options->getProjectTemplate(), 'Set/got default "project-template" option.');
     self::assertNull($options->getSut(), 'Set/got default "sut" option.');
     self::assertTrue($options->installSite(), 'Set/got default "no-site-install" option.');
     self::assertTrue($options->useSqlite(), 'Set/got default "no-sqlite" option.');


### PR DESCRIPTION
DRP is supposed to make D11 related changes to its `master` branch, so we are trying to work around and pinning to 2.x branch  for D11. This would enable DRP to create a D11 related release without breaking ORCA. Once the release is done we will again fallback to the current configuration.