### PR TITLE
Update Mautic matrix

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -138,7 +138,7 @@ acquia/memcache-settings:
 
 drupal/mautic:
   core_matrix:
-    11.x:
+    '10.* || 11.*':
       version: ~
       version_dev: ~
     '*': []


### PR DESCRIPTION
Mautic is failing in both D10 and D11, so removing it from the RCAT fixtures.