### PR TITLE
Make live tests required to pass

### DIFF
--- a/bin/ci/self-test/_includes.sh
+++ b/bin/ci/self-test/_includes.sh
@@ -12,8 +12,6 @@
 source ../_includes.sh
 
 if [[ "$ORCA_LIVE_TEST" ]]; then
-  set +e
-  notice "This job is allowed to fail and will report as passing regardless of outcome."
   unset ORCA_PACKAGES_CONFIG
   unset ORCA_PACKAGES_CONFIG_ALTER
 fi


### PR DESCRIPTION
- Let's make live tests required to pass so that failures are not masked out. This does not impact any customer because it is only used by the RCAT team.