### PR TITLE
Post D11 pipeline changes

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -61,17 +61,10 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-        php-version: [ "8.1", "8.3" ]
+        php-version: [ "8.3" ]
         orca-enable-nightwatch: [ "FALSE" ]
         orca-coverage-enable: [ "TRUE" ]
         include:
-          # Testing Drupal 10 in php 8.1 with nightwatch and coverage.
-          - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "8.1"
-            orca-enable-nightwatch: "TRUE"
-            # Testing coverage generation in Clover format when ORCA_COVERAGE_ENABLE is TRUE.
-            orca-coverage-enable: "TRUE"
-
           # Testing Drupal 10 in php 8.3.
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.3"
@@ -83,21 +76,29 @@ jobs:
           - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
             php-version: "8.1"
 
-          # Testing Drupal 11 in php 8.3.
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
+          # Testing Drupal 10 in php 8.1.
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
+            php-version: "8.1"
 
-          # Testing Drupal 11 in php 8.3.
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
+          # Testing Drupal 10 in php 8.1.
+          - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
+            php-version: "8.1"
 
-          # Testing Drupal 11 in php 8.3.
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
-
-          # Testing Drupal 11 in php 8.3.
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
+#          # Testing Drupal 11 in php 8.3.
+#          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+#            php-version: "8.3"
+#
+#          # Testing Drupal 11 in php 8.3.
+#          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+#            php-version: "8.3"
+#
+#          # Testing Drupal 11 in php 8.3.
+#          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+#            php-version: "8.3"
+#
+#          # Testing Drupal 11 in php 8.3.
+#          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+#            php-version: "8.3"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
PHP 8.1 should only be used to run the following jobs -
-- EOL_MAJOR
-- OLDEST_SUPPORTED 
-- LATEST_LTS